### PR TITLE
Add information about '/ecoenchants toggledescriptions' command

### DIFF
--- a/docs/ecoenchants/commands-and-permissions.md
+++ b/docs/ecoenchants/commands-and-permissions.md
@@ -32,6 +32,14 @@ Permission: `ecoenchants.command.export`
 
 General Usage: `/ecoenchants export <id>`
 
+## `/ecoenchants toggledescriptions` (Let players toggle enchantment descriptions)
+Permission: `ecoenchants.command.toggledescriptions`
+
+General Usage: `/ecoenchants toggledescriptions`
+
+Let players decide whether they want to see enchantment descriptions or not.
+This command only works when enchantment descriptions are enabled in the config.
+
 ## Enchantment Permissions
 
 Want to make an enchantment only available through an enchanting table for certain players?


### PR DESCRIPTION
The /ecoenchants toggledescriptions command as well as the permission node used for this command are missing in wiki.