### PR TITLE
Add docs for new effect triggers, conditions, and filters

### DIFF
--- a/docs/effects/all-conditions/has_town_role.md
+++ b/docs/effects/all-conditions/has_town_role.md
@@ -1,0 +1,12 @@
+# `has_town_role`
+
+Requires a player to have a certain role in a town
+
+**Requires HuskTowns**
+# Example Config
+```yaml
+- id: has_town_role
+  args:
+    roles: # The ID of the role
+      - captain
+```

--- a/docs/effects/all-conditions/in_own_claim.md
+++ b/docs/effects/all-conditions/in_own_claim.md
@@ -1,0 +1,9 @@
+# `in_own_claim`
+
+Requires the player to be in their own claim
+
+**Requires HuskClaims or HuskTowns**
+# Example Config
+```yaml
+- id: in_own_claim
+```

--- a/docs/effects/all-conditions/is_season.md
+++ b/docs/effects/all-conditions/is_season.md
@@ -1,0 +1,14 @@
+# `is_season`
+
+Requires it to be a certain season
+
+**Requires CustomCrops**
+# Example Config
+```yaml
+- id: is_season
+  args:
+	season: summer # Use for a single season
+    seasons: # Use for multiple seasons
+	  - summer
+	  - spring
+```

--- a/docs/effects/all-filters/custom_crop_stage.md
+++ b/docs/effects/all-filters/custom_crop_stage.md
@@ -1,0 +1,12 @@
+# `custom_crop_stage`
+
+The list of crop stages the effect should activate on
+
+**Requires CustomCrops**
+# Example Config
+```yaml
+filters:
+  custom_crop_stage: 
+    - apple_stage_6 # The stage ID, in the CustomCrops config this is "model"
+    - cabbage_stage_4
+```

--- a/docs/effects/all-filters/custom_crop_type.md
+++ b/docs/effects/all-filters/custom_crop_type.md
@@ -1,0 +1,12 @@
+# `custom_crop_type`
+
+The list of crop types the effect should activate on
+
+**Requires CustomCrops**
+# Example Config
+```yaml
+filters:
+  custom_crop_type: 
+    - tomato # The crop ID from the CustomCrops configs
+    - cabbage
+```

--- a/docs/effects/all-filters/custom_fish_type.md
+++ b/docs/effects/all-filters/custom_fish_type.md
@@ -1,0 +1,20 @@
+# `custom_fish_type`
+
+The list of fish types the effect should activate on
+
+**Requires CustomFishing**
+# Example Config
+```yaml
+filters:
+  custom_fish_type: 
+    - radioactive_fish # The fish ID from the CustomFishing configs.
+    - tuna_fish
+    - cod
+```
+
+:::note  
+  
+If the fish type is vanilla, you should use the Minecraft ID (eg: cod, salmon).
+If the fish type is from CustomFishing, use the ID from the configs.
+
+:::

--- a/docs/effects/all-filters/fertilizer_type.md
+++ b/docs/effects/all-filters/fertilizer_type.md
@@ -1,0 +1,12 @@
+# `fertilizer_type`
+
+The list of fertilizers the effect should activate on
+
+**Requires CustomCrops**
+# Example Config
+```yaml
+filters:
+  fertilizer_type: 
+    - quality_1 # The fertilizer ID from the CustomCrops configs. 
+    - quality_2
+```

--- a/docs/effects/all-filters/town_role.md
+++ b/docs/effects/all-filters/town_role.md
@@ -1,0 +1,12 @@
+# `town_role`
+
+The list of town roles the effect should activate on
+
+**Requires HuskTowns**
+# Example Config
+```yaml
+filters:
+  town_role: 
+    - captain
+    - mayor
+```

--- a/docs/effects/all-filters/watering_can_type.md
+++ b/docs/effects/all-filters/watering_can_type.md
@@ -1,0 +1,12 @@
+# `watering_can_type`
+
+The list of watering cans the effect should activate on
+
+**Requires CustomCrops**
+# Example Config
+```yaml
+filters:
+  watering_can_type: 
+    - watering_can_1 # The watering can ID from the CustomCrops configs. 
+    - watering_can_2
+```

--- a/docs/effects/all-triggers.md
+++ b/docs/effects/all-triggers.md
@@ -14,7 +14,7 @@ and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
 | `beacon_effect`                 | Triggered when a player gains effects from a beacon **Requires Paper**                                            | 1                                             |
 | `bite`                          | Triggered when a fish bites on your rod                                                                           | 1                                             |
 | `block_item_drop`               | Triggered when a mined block drops loot                                                                           | The amount of items dropped                   |
-| `bonemeal_crop`                 | Triggered when using bonemeal on a crop                                                                           | 1                                             |
+| `bonemeal_crop`                 | Triggered when using bonemeal on a crop **Supports CustomCrops**                                                  | 1                                             |
 | `bow_attack`                    | Triggered when shooting an entity with a bow and arrow (or crossbow)                                              | The damage dealt                              |
 | `breed`                         | Triggered when breeding entities together                                                                         | The experience received                       |
 | `brew`                          | Triggered when brewing a potion in a brewing stand                                                                | 1                                             |
@@ -26,8 +26,10 @@ and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
 | `catch_fish_fail`               | Triggered when failing to catch a fish                                                                            | 1                                             |
 | `change_armor`                  | Triggered when changing armor                                                                                     | 1                                             |
 | `change_chunk`                  | Triggered when changing chunk                                                                                     | 1                                             |
+| `change_town_role`              | Triggered when changing town role **Requires HuskTowns**                                                          | 1                                             |
 | `change_world`                  | Triggered when changing world                                                                                     | 1                                             |
 | `claim_battlepass_reward`       | Triggered when claiming a battlepass reward **Requires xBattlepass**                                              | 1                                             |
+| `claim_land`                    | Triggered when claiming land **Requires HuskTowns \|\| HuskClaims**                                               | 1                                             |
 | `click_block`                   | Triggered when right-clicking on a block                                                                          | 1                                             |
 | `click_entity`                  | Triggered when right-clicking on an entity                                                                        | 1                                             |
 | `collect_envoy`                 | Triggered when collecting an envoy crate **Requires AxEnvoy**                                                     | 1                                             |
@@ -37,10 +39,12 @@ and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
 | `complete_task`                 | Triggered when completing a task **Requires EcoQuests**                                                           | 1                                             |
 | `consume`                       | Triggered on item consumption                                                                                     | 1                                             |
 | `craft`                         | Triggered when crafting an item                                                                                   | The amount of items crafted                   |
+| `create_town`                   | Triggered when creating a Town **Requires HuskTowns**                                                             | 1                                             |
 | `damage_item`                   | Triggered when damaging an item                                                                                   | The damage                                    |
 | `death`                         | Triggered on death from any sources                                                                               | 1                                             |
 | `deploy_elytra`                 | Triggered when the player starts elytra gliding                                                                   | 1                                             |
 | `disable`                       | Triggered when an item / enchant / etc disables                                                                   | 1                                             |
+| `disband_town`                  | Triggered when disbanding a Town **Requires HuskTowns**                                                           | 1                                             |
 | `drop_item`                     | Triggered when dropping an item                                                                                   | The amount of items                           |
 | `elytra_boost`                  | Triggered when a player boosts an elytra **Requires Paper**                                                       | 1                                             |
 | `empty_bucket`                  | Triggered when emptying a bucket                                                                                  | 1                                             |
@@ -48,6 +52,7 @@ and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
 | `enchant_<type>`                | Triggered when enchanting an item with a certain type of enchantment **Requires EcoEnchants**                     | The xp cost                                   |
 | `enchant_item`                  | Triggered when enchanting an item                                                                                 | The xp cost                                   |
 | `enter_bed`                     | Triggered when entering a bed                                                                                     | 1                                             |
+| `enter_claimed_land`            | Triggered when entering claimed land **Requires HuskTowns \|\| HuskClaims**                                       | 1                                             |
 | `enter_region`                  | Triggered when entering a region **Requires WorldGuard**                                                          | 1                                             |
 | `entity_break_door`             | Triggered when an entity breaks a door                                                                            | 1                                             |
 | `entity_catch_fire_from_block`  | Triggered when an entity catches fire from a block                                                                | 1                                             |
@@ -70,6 +75,7 @@ and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
 | `gain_task_xp`                  | Triggered when gaining task XP **Requires EcoQuests**                                                             | The experience gained                         |
 | `gain_xp`                       | Triggered when gaining experience points                                                                          | The xp gained                                 |
 | `global_static_%interval%`      | Run every x ticks for the server, eg `global_static_20` would run every second                                    | 1                                             |
+| `harvest_custom_crop`           | Triggered when harvesting a custom crop **Requires CustomCrops**                                                  | 1                                             |
 | `headshot`                      | Triggered when hitting an enemy with a projectile in the head                                                     | The damage dealt                              |
 | `heal`                          | Triggered when regaining health                                                                                   | The health regained                           |
 | `hold_item`                     | Triggered when changing your held item                                                                            | 1                                             |
@@ -79,13 +85,16 @@ and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
 | `jobs_level_up`                 | Triggered when levelling up a job **Requires Jobs Reborn**                                                        | The new level                                 |
 | `join`                          | Triggered when joining the server                                                                                 | 1                                             |
 | `join_job`                      | Triggered when joining a job **Requires EcoJobs**                                                                 | The job level                                 |
+| `join_town`                     | Triggered when joining a Town **Requires HuskTowns**                                                              | 1                                             |
 | `jump`                          | Triggered when Jumping (pressing space)                                                                           | 1                                             |
 | `kill`                          | Triggered when a player kills a player or entity                                                                  | The victim's max health                       |
 | `leash_entity`                  | Triggered when leashing an entity                                                                                 | 1                                             |
 | `leave`                         | Triggered when leaving the server                                                                                 | 1                                             |
 | `leave_bed`                     | Triggered when leaving a bed                                                                                      | 1                                             |
+| `leave_claimed_land`            | Triggered when leaving claimed land **Requires HuskTowns \|\| HuskClaims**                                        | 1                                             |
 | `leave_job`                     | Triggered when leaving a job **Requires EcoJobs**                                                                 | The job level                                 |
 | `leave_region`                  | Triggered when leaving a region **Requires WorldGuard**                                                           | 1                                             |
+| `leave_town`                    | Triggered when leaving a Town **Requires HuskTowns**                                                              | 1                                             |
 | `left_click_npc`                | Triggered when left-clicking an NPC **Requires Citizens \|\| FancyNpcs**                                          | 1                                             |
 | `level_down_mcmmo`              | Triggered when levelling down McMMO skill **Requires McMMO**                                                      | The new level                                 |
 | `level_up_item`                 | Triggered when levelling up an item                                                                               | The new item level                            |
@@ -104,6 +113,7 @@ and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
 | `move`                          | Triggered on all movement: looking around, walking                                                                | The distance moved                            |
 | `pick_up_item`                  | Triggered when picking up an item                                                                                 | The amount of items                           |
 | `place_block`                   | Triggered when placing a block                                                                                    | 1                                             |
+| `plant_custom_crop`             | Triggered when planting a custom crop **Requires CustomCrops**                                                    | 1                                             |
 | `player_trade`                  | Triggered when trading with a player **Required AxTrade**                                                         | The total amount of items traded              |
 | `potion_effect`                 | Triggered when gaining a potion effect                                                                            | 1                                             |
 | `projectile_hit`                | Triggered when hitting a block or an entity with a projectile (arrow, trident, splash potion, egg, snowball)      | 1                                             |
@@ -139,7 +149,10 @@ and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
 | `toggle_sprint`                 | Triggered when changing the sprint state                                                                          | 1                                             |
 | `trident_attack`                | Triggered on injuring an entity with a thrown trident **Requires Paper**                                          | The damage dealt                              |
 | `try_inscribe`                  | Triggered when attempting to inscribe a scroll **Requires EcoScrolls**                                            | 1                                             |
+| `unclaim_land`                  | Triggered when unclaiming land **Requires HuskTowns \|\| HuskClaims**                                             | 1                                             |
 | `unleash_entity`                | Triggered when unleashing an entity                                                                               | 1                                             |
+| `use_fertilizer`                | Triggered when using fertilizer **Requires CustomCrops**                                                          | 1                                             |
 | `use_flower_pot`                | Triggered when a player insets or extracts a plant from a flower pot **Requires Paper**                           | 1                                             |
+| `use_watering_can`              | Triggered when using a watering can **Requires CustomCrops**                                                      | 1                                             |
 | `villager_trade`                | Triggered when trading with a villager **Requires Paper**                                                         | The experience the villager gains             |
 | `win_raid`                      | Triggered when a player wins a raid                                                                               | The level of bad omen                         |

--- a/docs/effects/external-integrations/customcrops/_category_.json
+++ b/docs/effects/external-integrations/customcrops/_category_.json
@@ -1,0 +1,3 @@
+{
+    "label": "xBattlepass"
+}

--- a/docs/effects/external-integrations/customcrops/all-triggers.md
+++ b/docs/effects/external-integrations/customcrops/all-triggers.md
@@ -1,0 +1,18 @@
+---
+title: Triggers
+sidebar_position: 4
+---
+
+Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect
+is active
+
+Triggered effects also produce a value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
+and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+
+| ID                    | Description                                      | Value Provided |
+| --------------------- | ------------------------------------------------ | -------------- |
+| `bonemeal_crop`       | Triggered when applying bonemeal to custom crops | 1              |
+| `harvest_custom_crop` | Triggered when harvesting a custom crop          | 1              |
+| `plant_custom_crop`   | Triggered when planting a custom crop            | 1              |
+| `use_fertilizer`      | Triggered when using fertilizer                  | 1              |
+| `use_watering_can`    | Triggered when using a watering can              | 1              |

--- a/docs/effects/external-integrations/customcrops/conditions/_category_.json
+++ b/docs/effects/external-integrations/customcrops/conditions/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Conditions",
+    "position": 2
+}

--- a/docs/effects/external-integrations/customcrops/conditions/is_season.md
+++ b/docs/effects/external-integrations/customcrops/conditions/is_season.md
@@ -1,0 +1,14 @@
+# `is_season`
+
+Requires it to be a certain season
+
+**Requires CustomCrops**
+# Example Config
+```yaml
+- id: is_season
+  args:
+	season: summer # Use for a single season
+    seasons: # Use for multiple seasons
+	  - summer
+	  - spring
+```

--- a/docs/effects/external-integrations/customcrops/filters/_category_.json
+++ b/docs/effects/external-integrations/customcrops/filters/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Filters",
+    "position": 3
+}

--- a/docs/effects/external-integrations/customcrops/filters/custom_crop_stage.md
+++ b/docs/effects/external-integrations/customcrops/filters/custom_crop_stage.md
@@ -1,0 +1,12 @@
+# `custom_crop_stage`
+
+The list of crop stages the effect should activate on
+
+**Requires CustomCrops**
+# Example Config
+```yaml
+filters:
+  custom_crop_stage: 
+    - apple_stage_6 # The stage ID, in the CustomCrops config this is "model"
+    - cabbage_stage_4
+```

--- a/docs/effects/external-integrations/customcrops/filters/custom_crop_type.md
+++ b/docs/effects/external-integrations/customcrops/filters/custom_crop_type.md
@@ -1,0 +1,12 @@
+# `custom_crop_type`
+
+The list of crop types the effect should activate on
+
+**Requires CustomCrops**
+# Example Config
+```yaml
+filters:
+  custom_crop_type: 
+    - tomato # The crop ID from the CustomCrops configs
+    - cabbage
+```

--- a/docs/effects/external-integrations/customcrops/filters/fertilizer_type.md
+++ b/docs/effects/external-integrations/customcrops/filters/fertilizer_type.md
@@ -1,0 +1,12 @@
+# `fertilizer_type`
+
+The list of fertilizers the effect should activate on
+
+**Requires CustomCrops**
+# Example Config
+```yaml
+filters:
+  fertilizer_type: 
+    - quality_1 # The fertilizer ID from the CustomCrops configs. 
+    - quality_2
+```

--- a/docs/effects/external-integrations/customcrops/filters/watering_can_type.md
+++ b/docs/effects/external-integrations/customcrops/filters/watering_can_type.md
@@ -1,0 +1,12 @@
+# `watering_can_type`
+
+The list of watering cans the effect should activate on
+
+**Requires CustomCrops**
+# Example Config
+```yaml
+filters:
+  watering_can_type: 
+    - watering_can_1 # The watering can ID from the CustomCrops configs. 
+    - watering_can_2
+```

--- a/docs/effects/external-integrations/customfishing/_category_.json
+++ b/docs/effects/external-integrations/customfishing/_category_.json
@@ -1,0 +1,3 @@
+{
+    "label": "CustomFishing"
+}

--- a/docs/effects/external-integrations/customfishing/all-triggers.md
+++ b/docs/effects/external-integrations/customfishing/all-triggers.md
@@ -1,0 +1,16 @@
+---
+title: Triggers
+sidebar_position: 4
+---
+
+Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect
+is active
+
+Triggered effects also produce a value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
+and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+
+| ID                | Description                            | Value Provided |
+| ----------------- | -------------------------------------- | -------------- |
+| `catch_fish`      | Triggered when catching a fish         | 1              |
+| `catch_fish_fail` | Triggered when failing to catch a fish | 1              |
+

--- a/docs/effects/external-integrations/customfishing/filters/_category_.json
+++ b/docs/effects/external-integrations/customfishing/filters/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Filters",
+    "position": 3
+}

--- a/docs/effects/external-integrations/customfishing/filters/custom_fish_type.md
+++ b/docs/effects/external-integrations/customfishing/filters/custom_fish_type.md
@@ -1,0 +1,20 @@
+# `custom_fish_type`
+
+The list of fish types the effect should activate on
+
+**Requires CustomFishing**
+# Example Config
+```yaml
+filters:
+  custom_fish_type: 
+    - radioactive_fish # The fish ID from the CustomFishing configs.
+    - tuna_fish
+    - cod
+```
+
+:::note  
+  
+If the fish type is vanilla, you should use the Minecraft ID (eg: cod, salmon).
+If the fish type is from CustomFishing, use the ID from the configs.
+
+:::

--- a/docs/effects/external-integrations/huskclaims/_category_.json
+++ b/docs/effects/external-integrations/huskclaims/_category_.json
@@ -1,0 +1,3 @@
+{
+    "label": "HuskClaims"
+}

--- a/docs/effects/external-integrations/huskclaims/all-triggers.md
+++ b/docs/effects/external-integrations/huskclaims/all-triggers.md
@@ -1,0 +1,17 @@
+---
+title: Triggers
+sidebar_position: 4
+---
+
+Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect
+is active
+
+Triggered effects also produce a value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
+and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+
+| ID                   | Description                          | Value Provided |
+| -------------------- | ------------------------------------ | -------------- |
+| `claim_land`         | Triggered when claiming land         | 1              |
+| `enter_claimed_land` | Triggered when entering claimed land | 1              |
+| `leave_claimed_land` | Triggered when leaving claimed land  | 1              |
+| `unclaim_land`       | Triggered when unclaiming land       | 1              |

--- a/docs/effects/external-integrations/huskclaims/conditions/_category_.json
+++ b/docs/effects/external-integrations/huskclaims/conditions/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Conditions",
+    "position": 2
+}

--- a/docs/effects/external-integrations/huskclaims/conditions/in_own_claim.md
+++ b/docs/effects/external-integrations/huskclaims/conditions/in_own_claim.md
@@ -1,0 +1,9 @@
+# `in_own_claim`
+
+Requires the player to be in their own claim
+
+**Requires HuskClaims or HuskTowns**
+# Example Config
+```yaml
+- id: in_own_claim
+```

--- a/docs/effects/external-integrations/husktowns/_category_.json
+++ b/docs/effects/external-integrations/husktowns/_category_.json
@@ -1,0 +1,3 @@
+{
+    "label": "xBattlepass"
+}

--- a/docs/effects/external-integrations/husktowns/all-triggers.md
+++ b/docs/effects/external-integrations/husktowns/all-triggers.md
@@ -1,0 +1,22 @@
+---
+title: Triggers
+sidebar_position: 4
+---
+
+Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect
+is active
+
+Triggered effects also produce a value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
+and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+
+| ID                   | Description                          | Value Provided |
+| -------------------- | ------------------------------------ | -------------- |
+| `change_town_role`   | Triggered when chaing town role      | 1              |
+| `claim_land`         | Triggered when claiming land         | 1              |
+| `create_town`        | Triggered when creating a Town       | 1              |
+| `disband_town`       | Triggered when disbanding a Town     | 1              |
+| `enter_claimed_land` | Triggered when entering claimed land | 1              |
+| `join_town`          | Triggered when joining a Town        | 1              |
+| `leave_claimed_land` | Triggered when leaving claimed land  | 1              |
+| `leave_town`         | Triggered when leaving a Town        | 1              |
+| `unclaim_land`       | Triggered when unclaiming land       | 1              |

--- a/docs/effects/external-integrations/husktowns/conditions/_category_.json
+++ b/docs/effects/external-integrations/husktowns/conditions/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Conditions",
+    "position": 2
+}

--- a/docs/effects/external-integrations/husktowns/conditions/has_town_role.md
+++ b/docs/effects/external-integrations/husktowns/conditions/has_town_role.md
@@ -1,0 +1,12 @@
+# `has_town_role`
+
+Requires a player to have a certain role in a town
+
+**Requires HuskTowns**
+# Example Config
+```yaml
+- id: has_town_role
+  args:
+    roles: # The ID of the role
+      - captain
+```

--- a/docs/effects/external-integrations/husktowns/conditions/in_own_claim.md
+++ b/docs/effects/external-integrations/husktowns/conditions/in_own_claim.md
@@ -1,0 +1,9 @@
+# `in_own_claim`
+
+Requires the player to be in their own claim
+
+**Requires HuskClaims or HuskTowns**
+# Example Config
+```yaml
+- id: in_own_claim
+```

--- a/docs/effects/external-integrations/husktowns/filters/_category_.json
+++ b/docs/effects/external-integrations/husktowns/filters/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Filters",
+    "position": 3
+}

--- a/docs/effects/external-integrations/husktowns/filters/town_role.md
+++ b/docs/effects/external-integrations/husktowns/filters/town_role.md
@@ -1,0 +1,12 @@
+# `town_role`
+
+The list of town roles the effect should activate on
+
+**Requires HuskTowns**
+# Example Config
+```yaml
+filters:
+  town_role: 
+    - captain
+    - mayor
+```


### PR DESCRIPTION
Added documentation for new effect triggers, conditions, and filters related to CustomCrops, CustomFishing, HuskClaims, and HuskTowns integrations. Updated the all-triggers list to include new triggers such as claim_land, create_town, join_town, and others. Added new markdown files for conditions (e.g., has_town_role, in_own_claim, is_season) and filters (e.g., custom_crop_stage, custom_fish_type, town_role, watering_can_type), as well as integration-specific documentation and category files.