### PR TITLE
Update category labels for CustomCrops and HuskTowns

### DIFF
--- a/docs/effects/external-integrations/customcrops/_category_.json
+++ b/docs/effects/external-integrations/customcrops/_category_.json
@@ -1,3 +1,3 @@
 {
-    "label": "xBattlepass"
+    "label": "CustomCrops"
 }

--- a/docs/effects/external-integrations/husktowns/_category_.json
+++ b/docs/effects/external-integrations/husktowns/_category_.json
@@ -1,3 +1,3 @@
 {
-    "label": "xBattlepass"
+    "label": "HuskTowns"
 }


### PR DESCRIPTION
Changed the 'label' fields in the _category_.json files for CustomCrops and HuskTowns integrations to reflect their correct names instead of 'xBattlepass'.