### PR TITLE
Update cost exponent formula and configuration tips

### DIFF
--- a/docs/ecoenchants/advanced-configuration.md
+++ b/docs/ecoenchants/advanced-configuration.md
@@ -9,18 +9,25 @@ Cost exponent is a feature of anvils, which can increase or decrease cost based 
 
 The formula works as follows:
 
-```yaml
-cost = original_cost * exponent^original_cost
+```go
+cost = level^exponent + 1
 ```
 
-So, working with an exponent of 1.02 and an original cost of 25:
+So, working with an exponent of `1.02` and an original cost of `25`:
 
-```yaml
-cost = 25 * 1.02^25
+```go
+cost = 25^1.02 + 1
 ```
 
-This is then rounded up to the nearest whole number, so the cost in this example would then become 42.
+This is then **rounded up** to the nearest whole number, so the cost in this example would become **28. This formula ensures cost scaling stays fair, fun and consistent across all levels.
+#### Configuration Tips
 
+Set the `cost-exponent` in your config to control difficulty:
+
+- `0.8` → Easy
+- `0.9` → Balanced
+- `1.0` → Vanilla-like
+- `1.2` → Harder
 ## Enchantment Type Bias
 
 You might design some enchantment types (e.g. special enchantments) to be extremely rare, and require a lot of work to balance out their power.
@@ -34,9 +41,9 @@ By default, Razor has 5 Levels. So, to calculate the level to apply, a random nu
 The "band" for each level is calculated by dividing 1 by the amount of levels. This looks like this for an enchantment with 5 levels:
 
 | Level | Range      |
-|-------|------------|
+| ----- | ---------- |
 | 1     | 0 - 0.2    |
-| 2     | 0.21 - 0.4 | 
+| 2     | 0.21 - 0.4 |
 | 3     | 0.41 - 0.6 |
 | 4     | 0.61 - 0.8 |
 | 5     | 0.81 - 1   |


### PR DESCRIPTION
Revised the cost exponent formula to use 'cost = level^exponent + 1' and updated the example calculation. Added configuration tips for setting the cost exponent and clarified rounding behavior. Minor formatting improvements were also made.