### PR TITLE
Rename 'Example Config' to 'Condition Syntax' in docs

### DIFF
--- a/docs/effects/all-conditions/above_balance.md
+++ b/docs/effects/all-conditions/above_balance.md
@@ -4,7 +4,7 @@ Requires a player to have a certain amount of money
 
 **Requires Vault**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: above_balance
   args:

--- a/docs/effects/all-conditions/above_global_points.md
+++ b/docs/effects/all-conditions/above_global_points.md
@@ -2,7 +2,7 @@
 
 Requires the server to have a certain amount of points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: above_global_points
   args:

--- a/docs/effects/all-conditions/above_health_percent.md
+++ b/docs/effects/all-conditions/above_health_percent.md
@@ -2,7 +2,7 @@
 
 Requires a player to be above a certain % of their max health
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: above_health_percent
   args:

--- a/docs/effects/all-conditions/above_hunger_percent.md
+++ b/docs/effects/all-conditions/above_hunger_percent.md
@@ -2,7 +2,7 @@
 
 Requires a player to be above a certain % of their max hunger
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: above_hunger_percent
   args:

--- a/docs/effects/all-conditions/above_magic.md
+++ b/docs/effects/all-conditions/above_magic.md
@@ -4,7 +4,7 @@ Requires a player to have a certain amount of magic
 
 **Requires EcoSkills**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: above_magic
   args:

--- a/docs/effects/all-conditions/above_points.md
+++ b/docs/effects/all-conditions/above_points.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain amount of points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: above_points
   args:

--- a/docs/effects/all-conditions/above_xp_level.md
+++ b/docs/effects/all-conditions/above_xp_level.md
@@ -2,7 +2,7 @@
 
 Requires the player to be above a certain xp level
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: above_xp_level
   args:

--- a/docs/effects/all-conditions/above_y.md
+++ b/docs/effects/all-conditions/above_y.md
@@ -2,7 +2,7 @@
 
 Requires a player to be above a certain y level
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: above_y
   args:

--- a/docs/effects/all-conditions/any_of.md
+++ b/docs/effects/all-conditions/any_of.md
@@ -2,7 +2,7 @@
 
 Requires any of a certain list of conditions to be matched
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: any_of
   args:

--- a/docs/effects/all-conditions/at_least_of.md
+++ b/docs/effects/all-conditions/at_least_of.md
@@ -2,7 +2,7 @@
 
 Requires at least a certain mount of a certain list of conditions to be met
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: at_least_of
   args:

--- a/docs/effects/all-conditions/below_balance.md
+++ b/docs/effects/all-conditions/below_balance.md
@@ -4,7 +4,7 @@ Requires a player to have below a certain amount of money
 
 **Requires Vault**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: below_balance
   args:

--- a/docs/effects/all-conditions/below_global_points.md
+++ b/docs/effects/all-conditions/below_global_points.md
@@ -2,7 +2,7 @@
 
 Requires the server to have a below an amount of points
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: below_global_points
   args:

--- a/docs/effects/all-conditions/below_health_percent.md
+++ b/docs/effects/all-conditions/below_health_percent.md
@@ -2,7 +2,7 @@
 
 Requires a player to be below a certain % of their max health
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: below_health_percent
   args:

--- a/docs/effects/all-conditions/below_hunger_percent.md
+++ b/docs/effects/all-conditions/below_hunger_percent.md
@@ -2,7 +2,7 @@
 
 Requires a player to be below a certain % of their max hunger
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: below_hunger_percent
   args:

--- a/docs/effects/all-conditions/below_magic.md
+++ b/docs/effects/all-conditions/below_magic.md
@@ -4,7 +4,7 @@ Requires a player to have less than a certain amount of magic
 
 **Requires EcoSkills**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: below_magic
   args:

--- a/docs/effects/all-conditions/below_points.md
+++ b/docs/effects/all-conditions/below_points.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a below amount of points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: below_points
   args:

--- a/docs/effects/all-conditions/below_xp_level.md
+++ b/docs/effects/all-conditions/below_xp_level.md
@@ -2,7 +2,7 @@
 
 Requires a player to be below a certain XP level
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: below_xp_level
   args:

--- a/docs/effects/all-conditions/below_y.md
+++ b/docs/effects/all-conditions/below_y.md
@@ -2,7 +2,7 @@
 
 Requires a player to be below a certain y level
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: below_y
   args:

--- a/docs/effects/all-conditions/can_afford_price.md
+++ b/docs/effects/all-conditions/can_afford_price.md
@@ -2,7 +2,7 @@
 
 Requires a player to be able to afford a certain [price](https://plugins.auxilor.io/all-plugins/prices)
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: can_afford_price
   args:

--- a/docs/effects/all-conditions/global_points_equal.md
+++ b/docs/effects/all-conditions/global_points_equal.md
@@ -2,7 +2,7 @@
 
 Requires the server to have a exactly a certain amount of points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: global_points_equal
   args:

--- a/docs/effects/all-conditions/has_active_job.md
+++ b/docs/effects/all-conditions/has_active_job.md
@@ -4,7 +4,7 @@ Requires a player to have a job active
 
 **Requires EcoJobs**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_active_job
   args:

--- a/docs/effects/all-conditions/has_active_pet.md
+++ b/docs/effects/all-conditions/has_active_pet.md
@@ -4,7 +4,7 @@ Requires a player to have a pet active
 
 **Requires EcoPets**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_active_pet
   args:

--- a/docs/effects/all-conditions/has_battlepass_tier.md
+++ b/docs/effects/all-conditions/has_battlepass_tier.md
@@ -3,7 +3,7 @@
 Requires a player to have a certain battlepass tier
 
 **Requires xBattlepass**
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_battlepass_tier
   args:

--- a/docs/effects/all-conditions/has_boss_bar_visible.md
+++ b/docs/effects/all-conditions/has_boss_bar_visible.md
@@ -4,7 +4,7 @@ Requires a player to have the TAB boss bar shown to them
 
 **Requires TAB**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_boss_bar_visible
 ```

--- a/docs/effects/all-conditions/has_completed_advancement.md
+++ b/docs/effects/all-conditions/has_completed_advancement.md
@@ -4,7 +4,7 @@ Requires a player to have completed an advancement
 
 A list of advancement keys can be found [here](https://minecraft.fandom.com/wiki/Advancement)
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_completed_advancement
   args:

--- a/docs/effects/all-conditions/has_completed_quest.md
+++ b/docs/effects/all-conditions/has_completed_quest.md
@@ -4,7 +4,7 @@ Requires a player to have completed a quest
 
 **Requires EcoQuests**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_completed_quest
   args:

--- a/docs/effects/all-conditions/has_completed_task.md
+++ b/docs/effects/all-conditions/has_completed_task.md
@@ -4,7 +4,7 @@ Requires a player to have completed task for a quest
 
 **Requires EcoQuests**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_completed_task
   args:

--- a/docs/effects/all-conditions/has_ecoitem.md
+++ b/docs/effects/all-conditions/has_ecoitem.md
@@ -4,7 +4,7 @@ Requires a player to have a certain EcoItem active
 
 **Requires EcoItems**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_ecoitem
   args:

--- a/docs/effects/all-conditions/has_enchant.md
+++ b/docs/effects/all-conditions/has_enchant.md
@@ -1,7 +1,7 @@
 # `has_enchant`
 
 Requires a player to have certain enchant(s)
-# Example Configs
+# Condition Syntaxs
 ```yaml
 - id: has_enchant
   args:

--- a/docs/effects/all-conditions/has_item.md
+++ b/docs/effects/all-conditions/has_item.md
@@ -2,7 +2,7 @@
 
 Requires a player to have an item in their inventory
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_item
   args:

--- a/docs/effects/all-conditions/has_item_data.md
+++ b/docs/effects/all-conditions/has_item_data.md
@@ -2,7 +2,7 @@
 
 Requires an item to have a certain data value present on it
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_item_data
   args:

--- a/docs/effects/all-conditions/has_job_level.md
+++ b/docs/effects/all-conditions/has_job_level.md
@@ -4,7 +4,7 @@ Requires a player to have a certain job level
 
 **Requires EcoJobs**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_job_level
   args:

--- a/docs/effects/all-conditions/has_lands_role.md
+++ b/docs/effects/all-conditions/has_lands_role.md
@@ -3,7 +3,7 @@
 Requires a player to have a certain role in the Land
 
 **Requires Lands**
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_lands_role
   args:

--- a/docs/effects/all-conditions/has_mana.md
+++ b/docs/effects/all-conditions/has_mana.md
@@ -4,7 +4,7 @@ Requires a player to have amount of mana
 
 **Requires AuraSkills**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_mana
   args:

--- a/docs/effects/all-conditions/has_mcmmo_level.md
+++ b/docs/effects/all-conditions/has_mcmmo_level.md
@@ -4,7 +4,7 @@ Requires a player to have a certain McMMO skill level
 
 **Requires McMMO**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_mcmmo_level
   args:

--- a/docs/effects/all-conditions/has_permission.md
+++ b/docs/effects/all-conditions/has_permission.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain permission
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_permission
   args:

--- a/docs/effects/all-conditions/has_pet.md
+++ b/docs/effects/all-conditions/has_pet.md
@@ -4,7 +4,7 @@ Requires a player to have a certain pet
 
 **Requires EcoPets**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_pet
   args:

--- a/docs/effects/all-conditions/has_pet_level.md
+++ b/docs/effects/all-conditions/has_pet_level.md
@@ -4,7 +4,7 @@ Requires a player to have a certain pet level
 
 **Requires EcoPets**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_pet_level
   args:

--- a/docs/effects/all-conditions/has_potion_effect.md
+++ b/docs/effects/all-conditions/has_potion_effect.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a [potion effect](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionEffectType.html) active
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_potion_effect
   args:

--- a/docs/effects/all-conditions/has_premium_battlepass.md
+++ b/docs/effects/all-conditions/has_premium_battlepass.md
@@ -3,7 +3,7 @@
 Requires a player to have the premium battlepass
 
 **Requires xBattlepass**
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_premium_battlepass
   args:

--- a/docs/effects/all-conditions/has_quest_active.md
+++ b/docs/effects/all-conditions/has_quest_active.md
@@ -4,7 +4,7 @@ Requires a player to have a quest active
 
 **Requires EcoQuests**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_quest_active
   args:

--- a/docs/effects/all-conditions/has_reforge.md
+++ b/docs/effects/all-conditions/has_reforge.md
@@ -4,7 +4,7 @@ Requires a player to have a certain reforge active
 
 **Requires Reforges**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_reforge
   args:

--- a/docs/effects/all-conditions/has_scoreboard_visible.md
+++ b/docs/effects/all-conditions/has_scoreboard_visible.md
@@ -4,7 +4,7 @@ Requires a player to have the TAB scoreboard shown to them
 
 **Requires TAB**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_scoreboard_visible
 ```

--- a/docs/effects/all-conditions/has_scroll.md
+++ b/docs/effects/all-conditions/has_scroll.md
@@ -4,7 +4,7 @@ Requires a player to have a certain scroll active
 
 **Requires EcoScrolls**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_scroll
   args:

--- a/docs/effects/all-conditions/has_skill_level.md
+++ b/docs/effects/all-conditions/has_skill_level.md
@@ -4,7 +4,7 @@ Requires a player to have a certain skill level
 
 **Requires EcoSkills or AuraSkills**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_skill_level
   args:

--- a/docs/effects/all-conditions/has_talisman.md
+++ b/docs/effects/all-conditions/has_talisman.md
@@ -4,7 +4,7 @@ Requires a player to have a certain talisman active
 
 **Requires Talismans**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_talisman
   args:

--- a/docs/effects/all-conditions/has_town_role.md
+++ b/docs/effects/all-conditions/has_town_role.md
@@ -3,7 +3,7 @@
 Requires a player to have a certain role in a town
 
 **Requires HuskTowns**
-# Example Config
+# Condition Syntax
 ```yaml
 - id: has_town_role
   args:

--- a/docs/effects/all-conditions/in_air.md
+++ b/docs/effects/all-conditions/in_air.md
@@ -2,7 +2,7 @@
 
 Requires a player to be in the air
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: in_air
 ```

--- a/docs/effects/all-conditions/in_biome.md
+++ b/docs/effects/all-conditions/in_biome.md
@@ -2,7 +2,7 @@
 
 Requires a player to be in a specific biome
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: in_biome
   args:

--- a/docs/effects/all-conditions/in_block.md
+++ b/docs/effects/all-conditions/in_block.md
@@ -2,7 +2,7 @@
 
 Requires a player to be in a block
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: in_block
 ```

--- a/docs/effects/all-conditions/in_bubble.md
+++ b/docs/effects/all-conditions/in_bubble.md
@@ -4,7 +4,7 @@ Requires a player to be in a bubble column
 
 **Requires Paper**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: in_bubble
 ```

--- a/docs/effects/all-conditions/in_gamemode.md
+++ b/docs/effects/all-conditions/in_gamemode.md
@@ -2,7 +2,7 @@
 
 Requires a player to be in specified gamemode
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: in_gamemode
   args:

--- a/docs/effects/all-conditions/in_lava.md
+++ b/docs/effects/all-conditions/in_lava.md
@@ -4,7 +4,7 @@ Requires a player to be in lava
 
 **Requires Paper**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: in_lava
 ```

--- a/docs/effects/all-conditions/in_mainhand.md
+++ b/docs/effects/all-conditions/in_mainhand.md
@@ -2,7 +2,7 @@
 
 Requires a player to have an item in their main hand
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: in_mainhand
   args:

--- a/docs/effects/all-conditions/in_offhand.md
+++ b/docs/effects/all-conditions/in_offhand.md
@@ -2,7 +2,7 @@
 
 Requires a player to have an item in their offhand
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: in_offhand
   args:

--- a/docs/effects/all-conditions/in_own_claim.md
+++ b/docs/effects/all-conditions/in_own_claim.md
@@ -3,7 +3,7 @@
 Requires the player to be in their own claim
 
 **Requires HuskClaims, HuskTowns or Lands**
-# Example Config
+# Condition Syntax
 ```yaml
 - id: in_own_claim
 ```

--- a/docs/effects/all-conditions/in_rain.md
+++ b/docs/effects/all-conditions/in_rain.md
@@ -4,7 +4,7 @@ Requires a player to be in rain
 
 **Requires Paper**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: in_rain
 ```

--- a/docs/effects/all-conditions/in_region.md
+++ b/docs/effects/all-conditions/in_region.md
@@ -4,7 +4,7 @@ Requires a player to be in a certain region
 
 **Requires WorldGuard**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: in_region
   args:

--- a/docs/effects/all-conditions/in_slot.md
+++ b/docs/effects/all-conditions/in_slot.md
@@ -7,7 +7,7 @@ This is useful if you want one holder to have different effects depending on the
 The options for slot are mainhand, offhand, hands, helmet, chestplate,
 leggings, boots, armor, any, or a number from 0-40 (to specify an exact slot).
 
-# Example Configs
+# Condition Syntaxs
 ```yaml
 - id: in_slot
   args:

--- a/docs/effects/all-conditions/in_trusted_claim.md
+++ b/docs/effects/all-conditions/in_trusted_claim.md
@@ -3,7 +3,7 @@
 Requires the player to be in a claim they're trusted in
 
 **Requires Lands**
-# Example Config
+# Condition Syntax
 ```yaml
 - id: in_trusted_claim
 ```

--- a/docs/effects/all-conditions/in_water.md
+++ b/docs/effects/all-conditions/in_water.md
@@ -2,7 +2,7 @@
 
 Requires a player to be in water
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: in_water
 ```

--- a/docs/effects/all-conditions/in_world.md
+++ b/docs/effects/all-conditions/in_world.md
@@ -2,7 +2,7 @@
 
 Requires a player to be in a certain world
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: in_world
   args:

--- a/docs/effects/all-conditions/is_alive.md
+++ b/docs/effects/all-conditions/is_alive.md
@@ -2,7 +2,7 @@
 
 Requires the player to be alive
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: is_alive
 ```

--- a/docs/effects/all-conditions/is_booster_active.md
+++ b/docs/effects/all-conditions/is_booster_active.md
@@ -4,7 +4,7 @@ Requires a certain booster to be active on the server
 
 **Requires Boosters**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: is_booster_active
   args:

--- a/docs/effects/all-conditions/is_expression_true.md
+++ b/docs/effects/all-conditions/is_expression_true.md
@@ -2,7 +2,7 @@
 
 Requires a certain expression to be true
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: is_expression_true
   args:

--- a/docs/effects/all-conditions/is_falling.md
+++ b/docs/effects/all-conditions/is_falling.md
@@ -2,7 +2,7 @@
 
 Requires a player to be falling
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: is_falling
 ```

--- a/docs/effects/all-conditions/is_flying.md
+++ b/docs/effects/all-conditions/is_flying.md
@@ -2,7 +2,7 @@
 
 Requires a player to be flying
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: is_flying
 ```

--- a/docs/effects/all-conditions/is_frozen.md
+++ b/docs/effects/all-conditions/is_frozen.md
@@ -2,7 +2,7 @@
 
 Requires a player to be frozen
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: is_frozen
 ```

--- a/docs/effects/all-conditions/is_gliding.md
+++ b/docs/effects/all-conditions/is_gliding.md
@@ -2,7 +2,7 @@
 
 Requires a player to be gliding with an elytra
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: is_gliding
 ```

--- a/docs/effects/all-conditions/is_night.md
+++ b/docs/effects/all-conditions/is_night.md
@@ -2,7 +2,7 @@
 
 Requires night
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: is_night
 ```

--- a/docs/effects/all-conditions/is_op.md
+++ b/docs/effects/all-conditions/is_op.md
@@ -2,7 +2,7 @@
 
 Requires a player to be an operator
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: is_op
 ```

--- a/docs/effects/all-conditions/is_season.md
+++ b/docs/effects/all-conditions/is_season.md
@@ -3,7 +3,7 @@
 Requires it to be a certain season
 
 **Requires CustomCrops**
-# Example Config
+# Condition Syntax
 ```yaml
 - id: is_season
   args:

--- a/docs/effects/all-conditions/is_sneaking.md
+++ b/docs/effects/all-conditions/is_sneaking.md
@@ -2,7 +2,7 @@
 
 Requires a player to be sneaking
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: is_sneaking
 ```

--- a/docs/effects/all-conditions/is_sprinting.md
+++ b/docs/effects/all-conditions/is_sprinting.md
@@ -2,7 +2,7 @@
 
 Requires a player to be sprinting
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: is_sprinting
 ```

--- a/docs/effects/all-conditions/is_storm.md
+++ b/docs/effects/all-conditions/is_storm.md
@@ -2,7 +2,7 @@
 
 Requires a player to be in a storm
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: is_storm
 ```

--- a/docs/effects/all-conditions/is_submerged.md
+++ b/docs/effects/all-conditions/is_submerged.md
@@ -2,7 +2,7 @@
 
 Requires a player to be fully submerged in liquid
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: is_submerged
 ```

--- a/docs/effects/all-conditions/is_swimming.md
+++ b/docs/effects/all-conditions/is_swimming.md
@@ -2,7 +2,7 @@
 
 Requires a player to be swimming
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: is_swimming
 ```

--- a/docs/effects/all-conditions/is_wearing_set.md
+++ b/docs/effects/all-conditions/is_wearing_set.md
@@ -4,7 +4,7 @@ Requires a player to be wearing a certain EcoArmor set
 
 **Requires EcoArmor**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: is_wearing_set
   args:

--- a/docs/effects/all-conditions/item_data_equals.md
+++ b/docs/effects/all-conditions/item_data_equals.md
@@ -2,7 +2,7 @@
 
 Requires an item to have a certain data value
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: item_data_equals
   args:

--- a/docs/effects/all-conditions/item_level_above.md
+++ b/docs/effects/all-conditions/item_level_above.md
@@ -2,7 +2,7 @@
 
 Requires an item to be above a certain level
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: item_level_above
   args:

--- a/docs/effects/all-conditions/item_level_below.md
+++ b/docs/effects/all-conditions/item_level_below.md
@@ -2,7 +2,7 @@
 
 Requires an item to be below a certain level
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: item_level_below
   args:

--- a/docs/effects/all-conditions/item_level_equals.md
+++ b/docs/effects/all-conditions/item_level_equals.md
@@ -2,7 +2,7 @@
 
 Requires an item to be on a certain level
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: item_level_equals
   args:

--- a/docs/effects/all-conditions/item_points_above.md
+++ b/docs/effects/all-conditions/item_points_above.md
@@ -2,7 +2,7 @@
 
 Requires an item to have a certain amount of points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: item_points_above
   args:

--- a/docs/effects/all-conditions/item_points_below.md
+++ b/docs/effects/all-conditions/item_points_below.md
@@ -2,7 +2,7 @@
 
 Requires an item to have below a certain amount of points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: item_points_below
   args:

--- a/docs/effects/all-conditions/item_points_equal.md
+++ b/docs/effects/all-conditions/item_points_equal.md
@@ -2,7 +2,7 @@
 
 Requires an item to have exactly a certain amount of points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: item_points_equal
   args:

--- a/docs/effects/all-conditions/lands_balance_above.md
+++ b/docs/effects/all-conditions/lands_balance_above.md
@@ -3,7 +3,7 @@
 Requires the Land's bank balance to be above a value
 
 **Requires Lands**
-# Example Config
+# Condition Syntax
 ```yaml
 - id: lands_balance_above
   args:

--- a/docs/effects/all-conditions/lands_balance_below.md
+++ b/docs/effects/all-conditions/lands_balance_below.md
@@ -3,7 +3,7 @@
 Requires the Land's bank balance to be below a value
 
 **Requires Lands**
-# Example Config
+# Condition Syntax
 ```yaml
 - id: lands_balance_below
   args:

--- a/docs/effects/all-conditions/lands_balance_equal.md
+++ b/docs/effects/all-conditions/lands_balance_equal.md
@@ -3,7 +3,7 @@
 Requires the Land's bank balance to be equal to a value
 
 **Requires Lands**
-# Example Config
+# Condition Syntax
 ```yaml
 - id: lands_balance_equal
   args:

--- a/docs/effects/all-conditions/light_level_below.md
+++ b/docs/effects/all-conditions/light_level_below.md
@@ -2,7 +2,7 @@
 
 Requires the light level to be less than or equal to certain level
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: light_level_below
   args:

--- a/docs/effects/all-conditions/mcmmo_ability_on_cooldown.md
+++ b/docs/effects/all-conditions/mcmmo_ability_on_cooldown.md
@@ -4,7 +4,7 @@ Requires an McMMO ability to be on cooldown
 
 **Requires McMMO**
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: mcmmo_ability_on_cooldown
   args:

--- a/docs/effects/all-conditions/near_entity.md
+++ b/docs/effects/all-conditions/near_entity.md
@@ -2,7 +2,7 @@
 
 Requires a player to be within a certain radius of an entity
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: near_entity
   args:

--- a/docs/effects/all-conditions/on_fire.md
+++ b/docs/effects/all-conditions/on_fire.md
@@ -2,7 +2,7 @@
 
 Requires a player to be on fire
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: on_fire
 ```

--- a/docs/effects/all-conditions/on_ground.md
+++ b/docs/effects/all-conditions/on_ground.md
@@ -2,7 +2,7 @@
 
 Requires a player to be on the ground
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: on_ground
 ```

--- a/docs/effects/all-conditions/placeholder_contains.md
+++ b/docs/effects/all-conditions/placeholder_contains.md
@@ -2,7 +2,7 @@
 
 Requires a placeholder to contain a certain value
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: placeholder_contains
   args:

--- a/docs/effects/all-conditions/placeholder_equals.md
+++ b/docs/effects/all-conditions/placeholder_equals.md
@@ -2,7 +2,7 @@
 
 Requires a placeholder to equal a certain value
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: placeholder_equals
   args:

--- a/docs/effects/all-conditions/placeholder_greater_than.md
+++ b/docs/effects/all-conditions/placeholder_greater_than.md
@@ -2,7 +2,7 @@
 
 Requires a placeholder to be greater than or equal to a certain value
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: placeholder_greater_than
   args:

--- a/docs/effects/all-conditions/placeholder_less_than.md
+++ b/docs/effects/all-conditions/placeholder_less_than.md
@@ -2,7 +2,7 @@
 
 Requires a placeholder to be less than a certain value
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: placeholder_less_than
   args:

--- a/docs/effects/all-conditions/points_equal.md
+++ b/docs/effects/all-conditions/points_equal.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a exactly a certain amount of points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: points_equal
   args:

--- a/docs/effects/all-conditions/riding_entity.md
+++ b/docs/effects/all-conditions/riding_entity.md
@@ -2,7 +2,7 @@
 
 Requires a player to be riding a certain entity
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: riding_entity
   args:

--- a/docs/effects/all-conditions/standing_on_block.md
+++ b/docs/effects/all-conditions/standing_on_block.md
@@ -2,7 +2,7 @@
 
 Requires a player to be standing on a block
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: standing_on_block
   args:

--- a/docs/effects/all-conditions/stat_above.md
+++ b/docs/effects/all-conditions/stat_above.md
@@ -4,7 +4,7 @@ Requires a player to have at least a certain stat level
 
 **Requires EcoSkills**
 
-# Example Config
+# Condition Syntax
 
 ```yaml
 - id: stat_above

--- a/docs/effects/all-conditions/stat_below.md
+++ b/docs/effects/all-conditions/stat_below.md
@@ -4,7 +4,7 @@ Requires a player to have less than a certain stat level
 
 **Requires EcoSkills**
 
-# Example Config
+# Condition Syntax
 
 ```yaml
 - id: stat_above

--- a/docs/effects/all-conditions/stat_equals.md
+++ b/docs/effects/all-conditions/stat_equals.md
@@ -4,7 +4,7 @@ Requires a player to have exactly a certain stat level
 
 **Requires EcoSkills**
 
-# Example Config
+# Condition Syntax
 
 ```yaml
 - id: stat_equals

--- a/docs/effects/all-conditions/wearing_boots.md
+++ b/docs/effects/all-conditions/wearing_boots.md
@@ -2,7 +2,7 @@
 
 Requires a player to have an item as their boots
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: wearing_boots
   args:

--- a/docs/effects/all-conditions/wearing_chestplate.md
+++ b/docs/effects/all-conditions/wearing_chestplate.md
@@ -2,7 +2,7 @@
 
 Requires a player to have an item as their chestplate
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: wearing_chestplate
   args:

--- a/docs/effects/all-conditions/wearing_helmet.md
+++ b/docs/effects/all-conditions/wearing_helmet.md
@@ -2,7 +2,7 @@
 
 Requires a player to have an item as their helmet
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: wearing_helmet
   args:

--- a/docs/effects/all-conditions/wearing_leggings.md
+++ b/docs/effects/all-conditions/wearing_leggings.md
@@ -2,7 +2,7 @@
 
 Requires a player to have an item as their leggings
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: wearing_leggings
   args:

--- a/docs/effects/all-conditions/within_radius_of.md
+++ b/docs/effects/all-conditions/within_radius_of.md
@@ -2,7 +2,7 @@
 
 Requires a player to be within a certain radius of a location
 
-# Example Config
+# Condition Syntax
 ```yaml
 - id: within_radius_of
   args:

--- a/docs/effects/all-effects/add_damage.md
+++ b/docs/effects/all-effects/add_damage.md
@@ -3,7 +3,7 @@
 
 Adds incoming or outgoing damage from any damage trigger
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: add_damage
   args:

--- a/docs/effects/all-effects/add_durability.md
+++ b/docs/effects/all-effects/add_durability.md
@@ -5,7 +5,7 @@ Increase the max durability of an item
 
 **Requires 1.21+**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: add_durability
   args:

--- a/docs/effects/all-effects/add_enchant.md
+++ b/docs/effects/all-effects/add_enchant.md
@@ -3,7 +3,7 @@
 
 Adds an enchant to the item
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: add_enchant
   args:

--- a/docs/effects/all-effects/add_global_points.md
+++ b/docs/effects/all-effects/add_global_points.md
@@ -3,7 +3,7 @@
 
 Add / subtract global points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: add_global_points
   args:

--- a/docs/effects/all-effects/add_holder.md
+++ b/docs/effects/all-effects/add_holder.md
@@ -7,7 +7,7 @@ A holder is anything with effects and conditions, in plugins typically a Talisma
 
 You can create custom holders temporarily and give them on a trigger, for example to give permanent effects for a period of time.
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: add_holder
   args:

--- a/docs/effects/all-effects/add_holder_in_radius.md
+++ b/docs/effects/all-effects/add_holder_in_radius.md
@@ -7,7 +7,7 @@ A holder is anything with effects and conditions, in plugins typically a Talisma
 
 You can create custom holders temporarily and give them on a trigger, for example to give permanent effects for a period of time to people around you.
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: add_holder_in_radius
   args:

--- a/docs/effects/all-effects/add_holder_to_victim.md
+++ b/docs/effects/all-effects/add_holder_to_victim.md
@@ -7,7 +7,7 @@ A holder is anything with effects and conditions, in plugins typically a Talisma
 
 You can create custom holders temporarily and give them on a trigger, for example to give permanent effects for a period of time.
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: add_holder_to_victim
   args:

--- a/docs/effects/all-effects/add_permanent_holder_in_radius.md
+++ b/docs/effects/all-effects/add_permanent_holder_in_radius.md
@@ -5,7 +5,7 @@ Gives a custom holder to people within a certain radius of you.
 
 A holder is anything with effects and conditions, in plugins typically a Talisman, Armor Set, etc.
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: add_permanent_holder_in_radius
   args:

--- a/docs/effects/all-effects/add_points.md
+++ b/docs/effects/all-effects/add_points.md
@@ -3,7 +3,7 @@
 
 Add / subtract points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: add_points
   args:

--- a/docs/effects/all-effects/add_stat.md
+++ b/docs/effects/all-effects/add_stat.md
@@ -5,7 +5,7 @@ Adds a value to a specific stat
 
 **Requires EcoSkills / AuraSkills**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: add_stat
   args:

--- a/docs/effects/all-effects/add_stat_temporarily.md
+++ b/docs/effects/all-effects/add_stat_temporarily.md
@@ -5,7 +5,7 @@ Adds a value to a specific stat
 
 **Requires EcoSkills**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: add_stat_temporarily
   args:

--- a/docs/effects/all-effects/age_crop.md
+++ b/docs/effects/all-effects/age_crop.md
@@ -3,7 +3,7 @@
 
 If the block is a crop, age it by a certain amount
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: age_crop
   args:

--- a/docs/effects/all-effects/all_players.md
+++ b/docs/effects/all-effects/all_players.md
@@ -3,7 +3,7 @@
 
 Runs effects for all players on the server
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: all_players
   args:

--- a/docs/effects/all-effects/animation.md
+++ b/docs/effects/all-effects/animation.md
@@ -10,7 +10,7 @@ Plays an animation
 | ----------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `spin_item` | Spin items around in a ring | `item` The item <br/> `amount` The amount of items <br/> `duration` The duration of the animation <br/> `radius` The radius of the ring <br/> `speed` The speed at which the items spin |
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: animation

--- a/docs/effects/all-effects/aoe.md
+++ b/docs/effects/all-effects/aoe.md
@@ -14,7 +14,7 @@ Runs effects for all entities within an area of effect (aoe)
 | `scan_in_front` | Scan for entities in the direction you're looking, and affect the first ones found | `radius` The radius of the scan <br /> `max_distance` The maximum distance to scan                                                                                                                       |
 | `beam`          | A beam in the direction you're looking                                             | `radius` The radius of the beam <br /> `distance` The length of the beam <br /> `pierce_blocks` If the beam should pass through blocks <br /> `pierce_entities` If the beam should pass through entities |
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: aoe

--- a/docs/effects/all-effects/aoe_blocks.md
+++ b/docs/effects/all-effects/aoe_blocks.md
@@ -6,7 +6,7 @@ Runs effects for all blocks within an area of effect
 
 The list of shapes is found [here](https://plugins.auxilor.io/effects/all-effects/aoe#list-of-shapes)
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: aoe

--- a/docs/effects/all-effects/armor.md
+++ b/docs/effects/all-effects/armor.md
@@ -3,7 +3,7 @@
 
 Gives armor points
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: armor
   args:

--- a/docs/effects/all-effects/armor_toughness.md
+++ b/docs/effects/all-effects/armor_toughness.md
@@ -3,7 +3,7 @@
 
 Gives armor toughness
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: armor_toughness
   args:

--- a/docs/effects/all-effects/arrow_ring.md
+++ b/docs/effects/all-effects/arrow_ring.md
@@ -3,7 +3,7 @@
 
 Spawns a ring of arrows around a location
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: arrow_ring
   args:

--- a/docs/effects/all-effects/attack_speed_multiplier.md
+++ b/docs/effects/all-effects/attack_speed_multiplier.md
@@ -3,7 +3,7 @@
 
 Multiplies attack speed
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: attack_speed_multiplier
   args:

--- a/docs/effects/all-effects/autosmelt.md
+++ b/docs/effects/all-effects/autosmelt.md
@@ -3,7 +3,7 @@
 
 Autosmelts drops (requires a drop trigger)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: autosmelt
   args:

--- a/docs/effects/all-effects/battlepass_task_xp_multiplier.md
+++ b/docs/effects/all-effects/battlepass_task_xp_multiplier.md
@@ -4,7 +4,7 @@
 Multiplies incoming battlepass task xp gain
 
 **Requires xBattlepass**
-# Example Config
+# Effect Syntax
 ```yaml
 - id: battlepass_task_xp_multiplier
   args:

--- a/docs/effects/all-effects/battlepass_xp_multiplier.md
+++ b/docs/effects/all-effects/battlepass_xp_multiplier.md
@@ -4,7 +4,7 @@
 Multiplies incoming battlepass xp gain
 
 **Requires xBattlepass**
-# Example Config
+# Effect Syntax
 ```yaml
 - id: battlepassxp_multiplier
   args:

--- a/docs/effects/all-effects/bleed.md
+++ b/docs/effects/all-effects/bleed.md
@@ -3,7 +3,7 @@
 
 Makes your victim bleed, damaging them repeatedly
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: bleed
   args:

--- a/docs/effects/all-effects/block_commands.md
+++ b/docs/effects/all-effects/block_commands.md
@@ -3,7 +3,7 @@
 
 Prevents the execution of certain commands
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: block_commands
   args:

--- a/docs/effects/all-effects/block_reach.md
+++ b/docs/effects/all-effects/block_reach.md
@@ -5,7 +5,7 @@ Adds reach for interacting with blocks
 
 **Requires 1.21+**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: block_reach
   args:

--- a/docs/effects/all-effects/bonus_health.md
+++ b/docs/effects/all-effects/bonus_health.md
@@ -3,7 +3,7 @@
 
 Gives extra health
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: bonus_health
   args:

--- a/docs/effects/all-effects/break_block.md
+++ b/docs/effects/all-effects/break_block.md
@@ -3,7 +3,7 @@
 
 Breaks a block instantly
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: break_block
   args:

--- a/docs/effects/all-effects/brew_time_multiplier.md
+++ b/docs/effects/all-effects/brew_time_multiplier.md
@@ -3,7 +3,7 @@
 
 Multiplies the time taken to brew potions
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: brew_time_multiplier
   args:

--- a/docs/effects/all-effects/broadcast.md
+++ b/docs/effects/all-effects/broadcast.md
@@ -3,7 +3,7 @@
 
 Send a message to everyone online
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: broadcast
   args:

--- a/docs/effects/all-effects/burning_time_multiplier.md
+++ b/docs/effects/all-effects/burning_time_multiplier.md
@@ -5,7 +5,7 @@ Multiplies how long an entity is on fire after being ignited
 
 **Requires 1.21+**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: burning_time_multiplier
   args:

--- a/docs/effects/all-effects/cancel_event.md
+++ b/docs/effects/all-effects/cancel_event.md
@@ -3,7 +3,7 @@
 
 Cancel the event that fired the trigger
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: cancel_event
   ...other config (eg triggers, filters, mutators, etc)

--- a/docs/effects/all-effects/clear_invulnerability.md
+++ b/docs/effects/all-effects/clear_invulnerability.md
@@ -4,7 +4,7 @@
 
 Removes the victim's invulnerability frame
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: clear_invulnerability

--- a/docs/effects/all-effects/close_inventory.md
+++ b/docs/effects/all-effects/close_inventory.md
@@ -3,7 +3,7 @@
 
 Closes the player's inventory
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: close_inventory
   ...other config (eg triggers, filters, mutators, etc)

--- a/docs/effects/all-effects/consume_held_item.md
+++ b/docs/effects/all-effects/consume_held_item.md
@@ -3,7 +3,7 @@
 
 Consume items held in the player's main hand
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: consume_held_item
   args:

--- a/docs/effects/all-effects/create_boss_bar.md
+++ b/docs/effects/all-effects/create_boss_bar.md
@@ -3,7 +3,7 @@
 
 Creates a boss bar and shows it to the player
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: create_boss_bar
   args:

--- a/docs/effects/all-effects/create_explosion.md
+++ b/docs/effects/all-effects/create_explosion.md
@@ -3,7 +3,7 @@
 
 Creates an explosion
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: create_explosion
   args:

--- a/docs/effects/all-effects/create_hologram.md
+++ b/docs/effects/all-effects/create_hologram.md
@@ -4,7 +4,7 @@
 
 Creates a hologram temporarily (Requires a hologram plugin to be installed)
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: create_hologram

--- a/docs/effects/all-effects/crit_multiplier.md
+++ b/docs/effects/all-effects/crit_multiplier.md
@@ -3,7 +3,7 @@
 
 Multiplies critical (falling) hit damage
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: crit_multiplier
   args:

--- a/docs/effects/all-effects/damage_armor.md
+++ b/docs/effects/all-effects/damage_armor.md
@@ -3,7 +3,7 @@
 
 Damage a victim's armor
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: damage_armor
   args:

--- a/docs/effects/all-effects/damage_item.md
+++ b/docs/effects/all-effects/damage_item.md
@@ -3,7 +3,7 @@
 
 Damages the item
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: damage_item
   args:

--- a/docs/effects/all-effects/damage_mainhand.md
+++ b/docs/effects/all-effects/damage_mainhand.md
@@ -3,7 +3,7 @@
 
 Damage a victim's mainhand item
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: damage_mainhand
   args:

--- a/docs/effects/all-effects/damage_multiplier.md
+++ b/docs/effects/all-effects/damage_multiplier.md
@@ -3,7 +3,7 @@
 
 Multiplies incoming or outgoing damage from any damage trigger
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: damage_multiplier
   args:

--- a/docs/effects/all-effects/damage_nearby_entities.md
+++ b/docs/effects/all-effects/damage_nearby_entities.md
@@ -3,7 +3,7 @@
 
 Damage entities near a location
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: damage_nearby_entities
   args:

--- a/docs/effects/all-effects/damage_offhand.md
+++ b/docs/effects/all-effects/damage_offhand.md
@@ -3,7 +3,7 @@
 
 Damage a victim's offhand item
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: damage_offhand
   args:

--- a/docs/effects/all-effects/damage_twice.md
+++ b/docs/effects/all-effects/damage_twice.md
@@ -3,7 +3,7 @@
 
 Deals an extra hit to the victim
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: damage_twice
   ...other config (eg triggers, filters, mutators, etc)

--- a/docs/effects/all-effects/damage_victim.md
+++ b/docs/effects/all-effects/damage_victim.md
@@ -3,7 +3,7 @@
 
 Damage the victim
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: damage_victim
   args:

--- a/docs/effects/all-effects/dont_consume_lapis_chance.md
+++ b/docs/effects/all-effects/dont_consume_lapis_chance.md
@@ -3,7 +3,7 @@
 
 Prevents consuming lapis when enchanting items
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: dont_consume_lapis_chance
   args:

--- a/docs/effects/all-effects/dont_consume_xp_chance.md
+++ b/docs/effects/all-effects/dont_consume_xp_chance.md
@@ -3,7 +3,7 @@
 
 Prevents consuming xp when enchanting items
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: dont_consume_xp_chance
   args:

--- a/docs/effects/all-effects/drill.md
+++ b/docs/effects/all-effects/drill.md
@@ -3,7 +3,7 @@
 
 Mine blocks behind the initial mined block
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: drill
   args:

--- a/docs/effects/all-effects/drop_item.md
+++ b/docs/effects/all-effects/drop_item.md
@@ -3,7 +3,7 @@
 
 Drops an item at a location
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: drop_item
   args:

--- a/docs/effects/all-effects/drop_item_slot.md
+++ b/docs/effects/all-effects/drop_item_slot.md
@@ -3,7 +3,7 @@
 
 Drops items from the player's inventory
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: drop_item_slot
   args:

--- a/docs/effects/all-effects/drop_pickup_item.md
+++ b/docs/effects/all-effects/drop_pickup_item.md
@@ -6,7 +6,7 @@ Drops an item that runs a chain on pickup
 
 **Requires Paper**
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: drop_pickup_item

--- a/docs/effects/all-effects/drop_random_item.md
+++ b/docs/effects/all-effects/drop_random_item.md
@@ -3,7 +3,7 @@
 
 Drops a random item at a location
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: drop_random_item
   args:

--- a/docs/effects/all-effects/drop_weighted_random_item.md
+++ b/docs/effects/all-effects/drop_weighted_random_item.md
@@ -3,7 +3,7 @@
 
 Drops a random item at a location, with weighting for different items
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: drop_weighted_random_item
   args:

--- a/docs/effects/all-effects/elytra_boost_save_chance.md
+++ b/docs/effects/all-effects/elytra_boost_save_chance.md
@@ -3,7 +3,7 @@
 
 Prevents consuming fireworks when boosting with an elytra
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: elytra_boost_save_chance
   args:

--- a/docs/effects/all-effects/entity_reach.md
+++ b/docs/effects/all-effects/entity_reach.md
@@ -5,7 +5,7 @@ Adds reach for interacting with entities
 
 **Requires 1.21+**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: entity_reach
   args:

--- a/docs/effects/all-effects/explosion_knockback_resistance_multiplier.md
+++ b/docs/effects/all-effects/explosion_knockback_resistance_multiplier.md
@@ -5,7 +5,7 @@ Multiplies explosion resistance
 
 **Requires 1.21+**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: explosion_knockback_resistance_multiplier
   args:

--- a/docs/effects/all-effects/extinguish.md
+++ b/docs/effects/all-effects/extinguish.md
@@ -3,7 +3,7 @@
 
 Extinguish the player
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: extinguish
   ...other config (eg triggers, filters, mutators, etc)

--- a/docs/effects/all-effects/feather_step.md
+++ b/docs/effects/all-effects/feather_step.md
@@ -3,7 +3,7 @@
 
 Prevents trampling crops
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: feather_step
 ```

--- a/docs/effects/all-effects/flight.md
+++ b/docs/effects/all-effects/flight.md
@@ -3,7 +3,7 @@
 
 Grants flight
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: flight
 ```

--- a/docs/effects/all-effects/food_multiplier.md
+++ b/docs/effects/all-effects/food_multiplier.md
@@ -3,7 +3,7 @@
 
 Multiplies food gain from eating
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: food_multiplier
   args:

--- a/docs/effects/all-effects/gain_task_xp.md
+++ b/docs/effects/all-effects/gain_task_xp.md
@@ -6,7 +6,7 @@ Gains experience points for a task in a quest, including multipliers.
 
 **Requires EcoQuests**
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: gain_task_xp

--- a/docs/effects/all-effects/give_battlepass_task_xp.md
+++ b/docs/effects/all-effects/give_battlepass_task_xp.md
@@ -4,7 +4,7 @@
 Gives experience points for a task in a quest, excluding multipliers.
 
 **Requires xBattlepass**
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_battlepass_task_xp
   args:

--- a/docs/effects/all-effects/give_battlepass_tier.md
+++ b/docs/effects/all-effects/give_battlepass_tier.md
@@ -4,7 +4,7 @@
 Give battlepass tiers to the player.
 
 **Requires xBattlepass**
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_battlepass_tier
   args:

--- a/docs/effects/all-effects/give_battlepass_xp.md
+++ b/docs/effects/all-effects/give_battlepass_xp.md
@@ -4,7 +4,7 @@
 Give battlepass experience points
 
 **Requires xBattlepass**
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_battlepass_xp
   args:

--- a/docs/effects/all-effects/give_food.md
+++ b/docs/effects/all-effects/give_food.md
@@ -3,7 +3,7 @@
 
 Gives the player food
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_food
   args:

--- a/docs/effects/all-effects/give_global_points.md
+++ b/docs/effects/all-effects/give_global_points.md
@@ -3,7 +3,7 @@
 
 Add / subtract global points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_global_points
   args:

--- a/docs/effects/all-effects/give_health.md
+++ b/docs/effects/all-effects/give_health.md
@@ -3,7 +3,7 @@
 
 Gives the player health
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_health
   args:

--- a/docs/effects/all-effects/give_item.md
+++ b/docs/effects/all-effects/give_item.md
@@ -3,7 +3,7 @@
 
 Gives a player an item
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_item
   args:

--- a/docs/effects/all-effects/give_item_points.md
+++ b/docs/effects/all-effects/give_item_points.md
@@ -3,7 +3,7 @@
 
 Add / subtract item points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_item_points
   args:

--- a/docs/effects/all-effects/give_job_xp.md
+++ b/docs/effects/all-effects/give_job_xp.md
@@ -5,7 +5,7 @@ Gives experience points for a certain job
 
 **Requires EcoJobs**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_job_xp
   args:

--- a/docs/effects/all-effects/give_lands_balance.md
+++ b/docs/effects/all-effects/give_lands_balance.md
@@ -6,7 +6,7 @@ Give money to a Land's bank balance
 
 **Requires Lands**
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: give_lands_balance

--- a/docs/effects/all-effects/give_magic.md
+++ b/docs/effects/all-effects/give_magic.md
@@ -5,7 +5,7 @@ Add / subtract magic
 
 **Requires EcoSkills**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_magic
   args:

--- a/docs/effects/all-effects/give_mcmmo_xp.md
+++ b/docs/effects/all-effects/give_mcmmo_xp.md
@@ -5,7 +5,7 @@ Gives experience points for a certain skill
 
 **Requires mcMMO**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_mcmmo_xp
   args:

--- a/docs/effects/all-effects/give_money.md
+++ b/docs/effects/all-effects/give_money.md
@@ -5,7 +5,7 @@ Gives a player money
 
 **Requires Vault economy**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_money
   args:

--- a/docs/effects/all-effects/give_oxygen.md
+++ b/docs/effects/all-effects/give_oxygen.md
@@ -3,7 +3,7 @@
 
 Give a player oxygen
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_oxygen
   args:

--- a/docs/effects/all-effects/give_permission.md
+++ b/docs/effects/all-effects/give_permission.md
@@ -5,7 +5,7 @@ Gives a permission while active
 
 **Requires Vault**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_permission
   args:

--- a/docs/effects/all-effects/give_pet_xp.md
+++ b/docs/effects/all-effects/give_pet_xp.md
@@ -5,7 +5,7 @@ Gives experience points for a certain pet
 
 **Requires EcoPets**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_pet_xp
   args:

--- a/docs/effects/all-effects/give_points.md
+++ b/docs/effects/all-effects/give_points.md
@@ -3,7 +3,7 @@
 
 Add / subtract points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_points
   args:

--- a/docs/effects/all-effects/give_price.md
+++ b/docs/effects/all-effects/give_price.md
@@ -3,7 +3,7 @@
 
 Pay a [price](https://plugins.auxilor.io/all-plugins/prices) to a player
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_price
   args:

--- a/docs/effects/all-effects/give_saturation.md
+++ b/docs/effects/all-effects/give_saturation.md
@@ -3,7 +3,7 @@
 
 Gives the player saturation
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_saturation
   args:

--- a/docs/effects/all-effects/give_skill_xp.md
+++ b/docs/effects/all-effects/give_skill_xp.md
@@ -5,7 +5,7 @@ Gives experience points for a certain skill
 
 **Requires EcoSkills**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_skill_xp
   args:

--- a/docs/effects/all-effects/give_skill_xp_naturally.md
+++ b/docs/effects/all-effects/give_skill_xp_naturally.md
@@ -7,7 +7,7 @@ This will send a message to a player and will include multipliers.
 
 **Requires EcoSkills**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_skill_xp_naturally
   args:

--- a/docs/effects/all-effects/give_task_xp.md
+++ b/docs/effects/all-effects/give_task_xp.md
@@ -6,7 +6,7 @@ Gives experience points for a task in a quest, excluding multipliers.
 
 **Requires EcoQuests**
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: give_task_xp

--- a/docs/effects/all-effects/give_xp.md
+++ b/docs/effects/all-effects/give_xp.md
@@ -3,7 +3,7 @@
 
 Gives experience points
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: give_xp
   args:

--- a/docs/effects/all-effects/glow_nearby_blocks.md
+++ b/docs/effects/all-effects/glow_nearby_blocks.md
@@ -3,7 +3,7 @@
 
 Make nearby blocks of a certain type glow a certain color
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: glow_nearby_blocks
   args:

--- a/docs/effects/all-effects/gravity_multiplier.md
+++ b/docs/effects/all-effects/gravity_multiplier.md
@@ -5,7 +5,7 @@ Multiplies gravity
 
 **Requires 1.21+**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: gravity_multiplier
   args:

--- a/docs/effects/all-effects/homing.md
+++ b/docs/effects/all-effects/homing.md
@@ -4,7 +4,7 @@
 
 Makes projectiles hone in onto entities (homing arrows / tridents)
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: homing

--- a/docs/effects/all-effects/hunger_multiplier.md
+++ b/docs/effects/all-effects/hunger_multiplier.md
@@ -3,7 +3,7 @@
 
 Multiplies hunger loss
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: hunger_multiplier
   args:

--- a/docs/effects/all-effects/ignite.md
+++ b/docs/effects/all-effects/ignite.md
@@ -3,7 +3,7 @@
 
 Lights the victim on fire
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: ignite
   args:

--- a/docs/effects/all-effects/increase_step_height.md
+++ b/docs/effects/all-effects/increase_step_height.md
@@ -5,7 +5,7 @@ Increases the amount of blocks you can walk over without jumping
 
 **Requires 1.21+**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: increase_step_height
   args:

--- a/docs/effects/all-effects/inscribe_item.md
+++ b/docs/effects/all-effects/inscribe_item.md
@@ -6,7 +6,7 @@ Inscribes an item with a scroll
 
 **Requires EcoScrolls**
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: inscribe_item

--- a/docs/effects/all-effects/item_durability_multiplier.md
+++ b/docs/effects/all-effects/item_durability_multiplier.md
@@ -5,7 +5,7 @@ Multiplies item durability (only works if holders are items, e.g. in EcoEnchants
 
 Item durability cannot actually be changed, so this functions like unbreaking where items will instead lose durability more quickly / slowly.
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: item_durability_multiplier
   args:

--- a/docs/effects/all-effects/job_xp_multiplier.md
+++ b/docs/effects/all-effects/job_xp_multiplier.md
@@ -5,7 +5,7 @@ Multiplies job xp gain
 
 **Requires EcoJobs**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: job_xp_multiplier
   args:

--- a/docs/effects/all-effects/jobs_money_multiplier.md
+++ b/docs/effects/all-effects/jobs_money_multiplier.md
@@ -5,7 +5,7 @@ Multiplies money gain from jobs
 
 **Requires Jobs Reborn**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: jobs_money_multiplier
   args:

--- a/docs/effects/all-effects/jobs_xp_multiplier.md
+++ b/docs/effects/all-effects/jobs_xp_multiplier.md
@@ -5,7 +5,7 @@ Multiplies xp gain from jobs
 
 **Requires Jobs Reborn**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: jobs_xp_multiplier
   args:

--- a/docs/effects/all-effects/jump_strength_multiplier.md
+++ b/docs/effects/all-effects/jump_strength_multiplier.md
@@ -5,7 +5,7 @@ Multiplies jump strength
 
 **Requires 1.21+**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: jump_strength_multiplier
   args:

--- a/docs/effects/all-effects/keep_inventory.md
+++ b/docs/effects/all-effects/keep_inventory.md
@@ -5,7 +5,7 @@ Gives the player keep inventory
 
 This will not make them keep their XP! Use `keep_level` as well if you want players to keep both items and XP.
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: keep_inventory
 ```

--- a/docs/effects/all-effects/keep_level.md
+++ b/docs/effects/all-effects/keep_level.md
@@ -3,7 +3,7 @@
 
 Makes the player keep their XP level on death
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: keep_level
 ```

--- a/docs/effects/all-effects/kick.md
+++ b/docs/effects/all-effects/kick.md
@@ -3,7 +3,7 @@
 
 Kicks the player
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: kick
   args:

--- a/docs/effects/all-effects/knock_away.md
+++ b/docs/effects/all-effects/knock_away.md
@@ -3,7 +3,7 @@
 
 Knock the victim away from the player
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: knock_away
   args:

--- a/docs/effects/all-effects/knockback_multiplier.md
+++ b/docs/effects/all-effects/knockback_multiplier.md
@@ -3,7 +3,7 @@
 
 Multiplies attack knockback
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: knockback_multiplier
   args:

--- a/docs/effects/all-effects/knockback_resistance_multiplier.md
+++ b/docs/effects/all-effects/knockback_resistance_multiplier.md
@@ -3,7 +3,7 @@
 
 Multiplies knockback resistance
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: knockback_resistance_multiplier
   args:

--- a/docs/effects/all-effects/level_item.md
+++ b/docs/effects/all-effects/level_item.md
@@ -3,7 +3,7 @@
 
 Gain item XP for a certain level
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: level_item
   args:

--- a/docs/effects/all-effects/luck_multiplier.md
+++ b/docs/effects/all-effects/luck_multiplier.md
@@ -3,7 +3,7 @@
 
 Multiplies luck
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: luck_multiplier
   args:

--- a/docs/effects/all-effects/magic_regen_multiplier.md
+++ b/docs/effects/all-effects/magic_regen_multiplier.md
@@ -5,7 +5,7 @@ Multiplies magic regeneration
 
 **Requires EcoSkills**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: magic_regen_multiplier
   args:

--- a/docs/effects/all-effects/make_skill_crit.md
+++ b/docs/effects/all-effects/make_skill_crit.md
@@ -5,7 +5,7 @@ Deal a crit hit
 
 **Requires EcoSkills**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: make_skill_crit
   args:

--- a/docs/effects/all-effects/mcmmo_xp_multiplier.md
+++ b/docs/effects/all-effects/mcmmo_xp_multiplier.md
@@ -5,7 +5,7 @@ Multiplies mcMMO skill xp gain
 
 **Requires mcMMO**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: mcmmo_xp_multiplier
   args:

--- a/docs/effects/all-effects/mine_radius.md
+++ b/docs/effects/all-effects/mine_radius.md
@@ -3,7 +3,7 @@
 
 Mines a square radius around a block
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: mine_radius
   args:

--- a/docs/effects/all-effects/mine_radius_one_deep.md
+++ b/docs/effects/all-effects/mine_radius_one_deep.md
@@ -3,7 +3,7 @@
 
 Mines a square radius around a block, but only one block deep
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: mine_radius_one_deep
   args:

--- a/docs/effects/all-effects/mine_vein.md
+++ b/docs/effects/all-effects/mine_vein.md
@@ -4,7 +4,7 @@
 
 Mines a vein of blocks
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: mine_vein

--- a/docs/effects/all-effects/mining_efficiency.md
+++ b/docs/effects/all-effects/mining_efficiency.md
@@ -5,7 +5,7 @@ Adds mining efficiency (mining speed when using the correct tool)
 
 **Requires 1.21+**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: mining_efficiency
   args:

--- a/docs/effects/all-effects/mining_speed_multiplier.md
+++ b/docs/effects/all-effects/mining_speed_multiplier.md
@@ -5,7 +5,7 @@ Multiplies mining speed
 
 **Requires 1.21+**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: mining_speed_multiplier
   args:

--- a/docs/effects/all-effects/mob_coins_chance_multiplier.md
+++ b/docs/effects/all-effects/mob_coins_chance_multiplier.md
@@ -5,7 +5,7 @@ Multiplies the chance of mobcoins being dropped
 
 **Requires UltimateMobCoins**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: mob_coins_chance_multiplier
   args:

--- a/docs/effects/all-effects/mob_coins_drop_multiplier.md
+++ b/docs/effects/all-effects/mob_coins_drop_multiplier.md
@@ -5,7 +5,7 @@ Multiplies the mobcoins dropped
 
 **Requires UltimateMobCoins**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: mob_coins_drop_multiplier
   args:

--- a/docs/effects/all-effects/mob_coins_multiplier.md
+++ b/docs/effects/all-effects/mob_coins_multiplier.md
@@ -5,7 +5,7 @@ Multiplies mob coin drops
 
 **Requires Flare Mobcoins**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: mob_coins_multiplier
   args:

--- a/docs/effects/all-effects/movement_efficiency_multiplier.md
+++ b/docs/effects/all-effects/movement_efficiency_multiplier.md
@@ -5,7 +5,7 @@ Multiplies movement speed through difficult terrain
 
 **Requires 1.21+**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: movement_efficiency_multiplier
   args:

--- a/docs/effects/all-effects/movement_speed_multiplier.md
+++ b/docs/effects/all-effects/movement_speed_multiplier.md
@@ -3,7 +3,7 @@
 
 Multiplies movement speed
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: movement_speed_multiplier
   args:

--- a/docs/effects/all-effects/multiply_all_stats.md
+++ b/docs/effects/all-effects/multiply_all_stats.md
@@ -5,7 +5,7 @@ Multiplies all stats by a specific value
 
 **Requires EcoSkills**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: multiply_all_stats
   args:

--- a/docs/effects/all-effects/multiply_drops.md
+++ b/docs/effects/all-effects/multiply_drops.md
@@ -3,7 +3,7 @@
 
 Multiplies drops (requires a drop trigger)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: multiply_drops
   args:
@@ -15,4 +15,8 @@ Multiplies drops (requires a drop trigger)
   ...other config (eg triggers, filters, mutators, etc)
 ```
 
+:::tip  
+  
 If you're experiencing drops not being multiplied, you may need to change the anti-duplication settings in [config.yml](https://github.com/Auxilor/libreforge/blob/master/core/common/src/main/resources/config.yml) and add blocks to the whitelist.
+
+:::

--- a/docs/effects/all-effects/multiply_global_points.md
+++ b/docs/effects/all-effects/multiply_global_points.md
@@ -3,7 +3,7 @@
 
 Multiply global points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: multiply_global_points
   args:

--- a/docs/effects/all-effects/multiply_item_points.md
+++ b/docs/effects/all-effects/multiply_item_points.md
@@ -3,7 +3,7 @@
 
 Multiply item points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: multiply_item_points
   args:

--- a/docs/effects/all-effects/multiply_magic.md
+++ b/docs/effects/all-effects/multiply_magic.md
@@ -5,7 +5,7 @@ Multiply magic
 
 **Requires EcoSkills**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: multiply_magic
   args:

--- a/docs/effects/all-effects/multiply_points.md
+++ b/docs/effects/all-effects/multiply_points.md
@@ -3,7 +3,7 @@
 
 Multiply points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: multiply_points
   args:

--- a/docs/effects/all-effects/multiply_stat.md
+++ b/docs/effects/all-effects/multiply_stat.md
@@ -5,7 +5,7 @@ Multiplies a stat by a specific value
 
 **Requires EcoSkills**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: multiply_stat
   args:

--- a/docs/effects/all-effects/multiply_stat_temporarily.md
+++ b/docs/effects/all-effects/multiply_stat_temporarily.md
@@ -5,7 +5,7 @@ Multiplies a stat by a specific value
 
 **Requires EcoSkills**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: multiply_stat_temporarily
   args:

--- a/docs/effects/all-effects/multiply_velocity.md
+++ b/docs/effects/all-effects/multiply_velocity.md
@@ -3,7 +3,7 @@
 
 Multiplies a players velocity
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: multiply_velocity
   args:

--- a/docs/effects/all-effects/name_entity.md
+++ b/docs/effects/all-effects/name_entity.md
@@ -3,7 +3,7 @@
 
 Set the display name of an entity
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: name_entity
   args:

--- a/docs/effects/all-effects/open_crafting.md
+++ b/docs/effects/all-effects/open_crafting.md
@@ -4,7 +4,7 @@
 
 Opens a crafting table for the player
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: open_crafting

--- a/docs/effects/all-effects/open_ender_chest.md
+++ b/docs/effects/all-effects/open_ender_chest.md
@@ -4,7 +4,7 @@
 
 Opens the player's ender chest
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: open_ender_chest

--- a/docs/effects/all-effects/particle_animation.md
+++ b/docs/effects/all-effects/particle_animation.md
@@ -15,7 +15,7 @@ Plays a particle animation
 | `double_helix`  | Draw a double helix of particles            | `height` The height to draw the helix <br/> `duration` The time taken to draw the helix, in ticks <br/> `speed` The speed at which to draw the helix <br/> `radius` The radius of the helix                                                              |
 | `twirl`         | Twirl particles (double expanding spiral)   | `small-radius` The small radius <br/> `large-radius` The large radius <br/> `duration` The animation duration, in ticks <br/> `start-height` The start height <br/> `end-height` The end height <br/> `speed` The speed at which to draw the animation   |
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: particle_animation

--- a/docs/effects/all-effects/particle_line.md
+++ b/docs/effects/all-effects/particle_line.md
@@ -3,7 +3,7 @@
 
 Spawns a line of particles between you and the target location
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: particle_line
   args:

--- a/docs/effects/all-effects/pay_price.md
+++ b/docs/effects/all-effects/pay_price.md
@@ -3,7 +3,7 @@
 
 Pay a [price](https://plugins.auxilor.io/all-plugins/prices)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: pay_price
   args:

--- a/docs/effects/all-effects/permanent_potion_effect.md
+++ b/docs/effects/all-effects/permanent_potion_effect.md
@@ -3,7 +3,7 @@
 
 Gives a permanent [potion effect](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionEffectType.html)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: permanent_potion_effect
   args:

--- a/docs/effects/all-effects/pet_xp_multiplier.md
+++ b/docs/effects/all-effects/pet_xp_multiplier.md
@@ -5,7 +5,7 @@ Multiplies pet xp gain
 
 **Requires EcoPets**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: pet_xp_multiplier
   args:

--- a/docs/effects/all-effects/piercing.md
+++ b/docs/effects/all-effects/piercing.md
@@ -4,7 +4,7 @@
 
 Makes projectiles pass through other entities (collaterals), like the Piercing enchantment.
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: piercing

--- a/docs/effects/all-effects/play_animation.md
+++ b/docs/effects/all-effects/play_animation.md
@@ -5,7 +5,7 @@ Plays a Model Engine animation (The entity must have a custom model active)
 
 **Requires Model Engine**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: play_animation
   args:

--- a/docs/effects/all-effects/play_sound.md
+++ b/docs/effects/all-effects/play_sound.md
@@ -3,7 +3,7 @@
 
 Plays a sound to the player
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: play_sound
   args:

--- a/docs/effects/all-effects/potion_duration_multiplier.md
+++ b/docs/effects/all-effects/potion_duration_multiplier.md
@@ -3,7 +3,7 @@
 
 Multiplies the duration of brewed potions
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: potion_duration_multiplier
   args:

--- a/docs/effects/all-effects/potion_effect.md
+++ b/docs/effects/all-effects/potion_effect.md
@@ -3,7 +3,7 @@
 
 Gives a [potion](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionEffectType.html) effect
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: potion_effect
   args:

--- a/docs/effects/all-effects/pull_in.md
+++ b/docs/effects/all-effects/pull_in.md
@@ -3,7 +3,7 @@
 
 Pull the victim towards the player
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: pull_in
   args:

--- a/docs/effects/all-effects/pull_to_location.md
+++ b/docs/effects/all-effects/pull_to_location.md
@@ -3,7 +3,7 @@
 
 Get pulled to a location
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: pull_to_location
   args:

--- a/docs/effects/all-effects/quest_xp_multiplier.md
+++ b/docs/effects/all-effects/quest_xp_multiplier.md
@@ -5,7 +5,7 @@ Multiplies quest xp gain
 
 **Requires EcoQuests**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: quest_xp_multiplier
   args:

--- a/docs/effects/all-effects/random_player.md
+++ b/docs/effects/all-effects/random_player.md
@@ -3,7 +3,7 @@
 
 Runs effects for a random player on the server
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: random_player
   args:

--- a/docs/effects/all-effects/rapid_bows.md
+++ b/docs/effects/all-effects/rapid_bows.md
@@ -3,7 +3,7 @@
 
 Allows bows to be shot at full speed without pulling back as far
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: rapid_bows
   args:

--- a/docs/effects/all-effects/reel_speed_multiplier.md
+++ b/docs/effects/all-effects/reel_speed_multiplier.md
@@ -3,7 +3,7 @@
 
 Multiplies the speed at which you pull in entities and drops with fishing rods
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: reel_speed_multiplier
   args:

--- a/docs/effects/all-effects/regen_multiplier.md
+++ b/docs/effects/all-effects/regen_multiplier.md
@@ -3,7 +3,7 @@
 
 Multiplies regen speed
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: regen_multiplier
   args:

--- a/docs/effects/all-effects/remove_boss_bar.md
+++ b/docs/effects/all-effects/remove_boss_bar.md
@@ -3,7 +3,7 @@
 
 Removes a boss bar
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: remove_boss_bar
   args:

--- a/docs/effects/all-effects/remove_enchant.md
+++ b/docs/effects/all-effects/remove_enchant.md
@@ -3,7 +3,7 @@
 
 Removes an enchant from the item
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: remove_enchant
   args:

--- a/docs/effects/all-effects/remove_item.md
+++ b/docs/effects/all-effects/remove_item.md
@@ -3,7 +3,7 @@
 
 Removes an item from the player's inventory
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: remove_item
   args:

--- a/docs/effects/all-effects/remove_item_data.md
+++ b/docs/effects/all-effects/remove_item_data.md
@@ -3,7 +3,7 @@
 
 Remove item data
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: remove_item_data
   args:

--- a/docs/effects/all-effects/remove_potion_effect.md
+++ b/docs/effects/all-effects/remove_potion_effect.md
@@ -3,7 +3,7 @@
 
 Removes a potion effect
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: remove_potion_effect
   args:

--- a/docs/effects/all-effects/repair_item.md
+++ b/docs/effects/all-effects/repair_item.md
@@ -3,7 +3,7 @@
 
 Repairs the item
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: repair_item
   args:

--- a/docs/effects/all-effects/replace_near.md
+++ b/docs/effects/all-effects/replace_near.md
@@ -3,7 +3,7 @@
 
 Replaces nearby blocks with other blocks
 
-# Example Configs
+# Effect Syntaxs
 ```yaml
 - id: replace_near
   args:

--- a/docs/effects/all-effects/replant_crops.md
+++ b/docs/effects/all-effects/replant_crops.md
@@ -3,7 +3,7 @@
 
 Automatically replants crops
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: replant_crops
   args:

--- a/docs/effects/all-effects/rotate.md
+++ b/docs/effects/all-effects/rotate.md
@@ -3,7 +3,7 @@
 
 Spin around
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: rotate
   args:

--- a/docs/effects/all-effects/rotate_victim.md
+++ b/docs/effects/all-effects/rotate_victim.md
@@ -3,7 +3,7 @@
 
 Spin the victim around
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: rotate_victim
   args:

--- a/docs/effects/all-effects/run_chain.md
+++ b/docs/effects/all-effects/run_chain.md
@@ -3,7 +3,7 @@
 
 Execute an effect chain
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: run_chain
   args:

--- a/docs/effects/all-effects/run_command.md
+++ b/docs/effects/all-effects/run_command.md
@@ -3,7 +3,7 @@
 
 Runs a command from console
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: run_command
   args:

--- a/docs/effects/all-effects/run_player_command.md
+++ b/docs/effects/all-effects/run_player_command.md
@@ -3,7 +3,7 @@
 
 Runs a command as a player
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: run_player_command
   args:

--- a/docs/effects/all-effects/safe_fall_distance.md
+++ b/docs/effects/all-effects/safe_fall_distance.md
@@ -5,7 +5,7 @@ Increases/decreases the distance you can fall without taking damage
 
 **Requires 1.21+**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: safe_fall_distance
   args:

--- a/docs/effects/all-effects/scale.md
+++ b/docs/effects/all-effects/scale.md
@@ -4,7 +4,7 @@
 Multiplies scale
 
 **Requires 1.21+**
-# Example Config
+# Effect Syntax
 ```yaml
 - id: scale
   args:

--- a/docs/effects/all-effects/sell_items.md
+++ b/docs/effects/all-effects/sell_items.md
@@ -3,7 +3,7 @@
 
 Sells dropped items / item from trigger
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: sell_items
   args:

--- a/docs/effects/all-effects/sell_multiplier.md
+++ b/docs/effects/all-effects/sell_multiplier.md
@@ -5,7 +5,7 @@ Multiplies money gained from selling items
 
 **Supports ShopGUIPlus, DeluxeSellwands, EconomyShopGUI, zShop**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: sell_multiplier
   args:

--- a/docs/effects/all-effects/send_message.md
+++ b/docs/effects/all-effects/send_message.md
@@ -3,7 +3,7 @@
 
 Sends the player a message
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: send_message
   args:

--- a/docs/effects/all-effects/send_minimessage.md
+++ b/docs/effects/all-effects/send_minimessage.md
@@ -5,7 +5,7 @@ Sends the player a minimessage message, supports clickable components, etc.
 
 **Requires Paper**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: send_minimessage
   args:

--- a/docs/effects/all-effects/send_title.md
+++ b/docs/effects/all-effects/send_title.md
@@ -3,7 +3,7 @@
 
 Send a title/subtitle to the player
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: send_title
   args:

--- a/docs/effects/all-effects/set_armor_trim.md
+++ b/docs/effects/all-effects/set_armor_trim.md
@@ -3,7 +3,7 @@
 
 Sets item armor trim
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: set_armor_trim
   args:

--- a/docs/effects/all-effects/set_battlepass_tier.md
+++ b/docs/effects/all-effects/set_battlepass_tier.md
@@ -4,7 +4,7 @@
 Set the player's battlepass tier
 
 **Requires xBattlepass**
-# Example Config
+# Effect Syntax
 ```yaml
 - id: set_battlepass_tier
   args:

--- a/docs/effects/all-effects/set_block.md
+++ b/docs/effects/all-effects/set_block.md
@@ -4,7 +4,7 @@
 
 Set a block
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: set_block

--- a/docs/effects/all-effects/set_custom_model_data.md
+++ b/docs/effects/all-effects/set_custom_model_data.md
@@ -3,7 +3,7 @@
 
 Set the item's custom model data
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: set_custom_model_data
   args:

--- a/docs/effects/all-effects/set_food.md
+++ b/docs/effects/all-effects/set_food.md
@@ -3,7 +3,7 @@
 
 Sets the player's food
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: set_food
   args:

--- a/docs/effects/all-effects/set_freeze_ticks.md
+++ b/docs/effects/all-effects/set_freeze_ticks.md
@@ -3,7 +3,7 @@
 
 Sets the victims freeze ticks (frost / powdered snow effect)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: set_freeze_ticks
   args:

--- a/docs/effects/all-effects/set_global_points.md
+++ b/docs/effects/all-effects/set_global_points.md
@@ -3,7 +3,7 @@
 
 Set global points (check the points wiki page if you don't know what these are)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: set_global_points
   args:

--- a/docs/effects/all-effects/set_item_data.md
+++ b/docs/effects/all-effects/set_item_data.md
@@ -3,7 +3,7 @@
 
 Set item data
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: set_item_data
   args:

--- a/docs/effects/all-effects/set_item_points.md
+++ b/docs/effects/all-effects/set_item_points.md
@@ -3,7 +3,7 @@
 
 Set item points (check the points wiki page if you don't know what these are)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: set_item_points
   args:

--- a/docs/effects/all-effects/set_lands_balance.md
+++ b/docs/effects/all-effects/set_lands_balance.md
@@ -6,7 +6,7 @@ Set the Land bank's balance
 
 **Requires Lands**
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: set_lands_balance

--- a/docs/effects/all-effects/set_points.md
+++ b/docs/effects/all-effects/set_points.md
@@ -3,7 +3,7 @@
 
 Set points (check the points wiki page if you don't know what these are)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: set_points
   args:

--- a/docs/effects/all-effects/set_saturation.md
+++ b/docs/effects/all-effects/set_saturation.md
@@ -3,7 +3,7 @@
 
 Sets the player's saturation
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: set_saturation
   args:

--- a/docs/effects/all-effects/set_velocity.md
+++ b/docs/effects/all-effects/set_velocity.md
@@ -3,7 +3,7 @@
 
 Sets your velocity
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: set_velocity
   args:

--- a/docs/effects/all-effects/set_victim_velocity.md
+++ b/docs/effects/all-effects/set_victim_velocity.md
@@ -3,7 +3,7 @@
 
 Sets the victim's velocity
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: set_victim_velocity
   args:

--- a/docs/effects/all-effects/shoot.md
+++ b/docs/effects/all-effects/shoot.md
@@ -3,7 +3,7 @@
 
 Shoots a [projectile](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/Projectile.html)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: shoot
   args:

--- a/docs/effects/all-effects/shoot_arrow.md
+++ b/docs/effects/all-effects/shoot_arrow.md
@@ -3,7 +3,7 @@
 
 Shoots an arrow
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: shoot_arrow
   args:

--- a/docs/effects/all-effects/shuffle_hotbar.md
+++ b/docs/effects/all-effects/shuffle_hotbar.md
@@ -3,7 +3,7 @@
 
 Shuffle your victim's hotbar
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: shuffle_hotbar
   ...other config (eg triggers, filters, mutators, etc)

--- a/docs/effects/all-effects/skill_xp_multiplier.md
+++ b/docs/effects/all-effects/skill_xp_multiplier.md
@@ -5,7 +5,7 @@ Multiplies skill xp gain
 
 **Requires EcoSkills / AuraSkills*
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: skill_xp_multiplier
   args:

--- a/docs/effects/all-effects/smite.md
+++ b/docs/effects/all-effects/smite.md
@@ -3,7 +3,7 @@
 
 Strikes lightning on a victim
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: smite
   args:

--- a/docs/effects/all-effects/sneaking_speed_multiplier.md
+++ b/docs/effects/all-effects/sneaking_speed_multiplier.md
@@ -5,7 +5,7 @@ Multiplies sneaking speed
 
 **Requires 1.21+**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: sneaking_speed_multiplier
   args:

--- a/docs/effects/all-effects/spawn_entity.md
+++ b/docs/effects/all-effects/spawn_entity.md
@@ -3,7 +3,7 @@
 
 Spawns an [entity](https://plugins.auxilor.io/all-plugins/the-entity-lookup-system)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: spawn_entity
   args:

--- a/docs/effects/all-effects/spawn_mobs.md
+++ b/docs/effects/all-effects/spawn_mobs.md
@@ -3,7 +3,7 @@
 
 Spawns [mobs](https://plugins.auxilor.io/all-plugins/the-entity-lookup-system) to help you
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: spawn_mobs
   args:

--- a/docs/effects/all-effects/spawn_particle.md
+++ b/docs/effects/all-effects/spawn_particle.md
@@ -3,7 +3,7 @@
 
 Spawns a [particle](https://plugins.auxilor.io/all-plugins/the-particle-lookup-system)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: spawn_particle
   args:

--- a/docs/effects/all-effects/spawn_potion_cloud.md
+++ b/docs/effects/all-effects/spawn_potion_cloud.md
@@ -3,7 +3,7 @@
 
 Spawns a [potion](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionEffectType.html) cloud
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: spawn_potion_cloud
   args:

--- a/docs/effects/all-effects/start_quest.md
+++ b/docs/effects/all-effects/start_quest.md
@@ -6,7 +6,7 @@ Starts a quest for the player
 
 **Requires EcoQuests**
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: start_quest

--- a/docs/effects/all-effects/strike_lightning.md
+++ b/docs/effects/all-effects/strike_lightning.md
@@ -3,7 +3,7 @@
 
 Strikes lightning at a point
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: strike_lightning
   args:

--- a/docs/effects/all-effects/strip_ai.md
+++ b/docs/effects/all-effects/strip_ai.md
@@ -3,7 +3,7 @@
 
 Strips a mob's AI temporarily
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: strip_ai
   args:

--- a/docs/effects/all-effects/swarm.md
+++ b/docs/effects/all-effects/swarm.md
@@ -4,7 +4,7 @@
 
 Makes nearby monsters in a certain radius attack the victim
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: swarm

--- a/docs/effects/all-effects/take_money.md
+++ b/docs/effects/all-effects/take_money.md
@@ -5,7 +5,7 @@ Takes money from the player
 
 **Requires Vault economy**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: take_money
   args:

--- a/docs/effects/all-effects/target_player.md
+++ b/docs/effects/all-effects/target_player.md
@@ -4,7 +4,7 @@
 
 Makes the victim target the player (requires the victim to be a monster)
 
-# Example Config
+# Effect Syntax
 
 ```yaml
 - id: target_player

--- a/docs/effects/all-effects/telekinesis.md
+++ b/docs/effects/all-effects/telekinesis.md
@@ -3,7 +3,7 @@
 
 Teleports all drops to the player's inventory
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: telekinesis
 ```

--- a/docs/effects/all-effects/teleport.md
+++ b/docs/effects/all-effects/teleport.md
@@ -3,7 +3,7 @@
 
 Teleports to a location
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: teleport
   ...other config (eg triggers, filters, mutators, etc)

--- a/docs/effects/all-effects/teleport_to.md
+++ b/docs/effects/all-effects/teleport_to.md
@@ -3,7 +3,7 @@
 
 Teleport a player to a specific location
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: teleport_to
   args:

--- a/docs/effects/all-effects/teleport_to_ground.md
+++ b/docs/effects/all-effects/teleport_to_ground.md
@@ -3,7 +3,7 @@
 
 Teleports to the ground
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: teleport_to_ground
   ...other config (eg triggers, filters, mutators, etc)

--- a/docs/effects/all-effects/total_damage_multiplier.md
+++ b/docs/effects/all-effects/total_damage_multiplier.md
@@ -6,7 +6,7 @@ Multiplies all incoming or outgoing damage from any damage trigger
 This effect **always** runs at the **end** of the run-order. This allows you to multiply other damage effects, such as damage added by the `add_damage` effect, as well as damage added by other plugins.
 
 Warning: This effect can lead to dealing big damage, in most cases you probably only want to use [`damage_multiplier`](https://plugins.auxilor.io/effects/all-effects/damage_multiplier)
-# Example Config
+# Effect Syntax
 ```yaml
 - id: total_damage_multiplier
   args:

--- a/docs/effects/all-effects/traceback.md
+++ b/docs/effects/all-effects/traceback.md
@@ -3,7 +3,7 @@
 
 Go back to a previous position
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: traceback
   args:

--- a/docs/effects/all-effects/transmission.md
+++ b/docs/effects/all-effects/transmission.md
@@ -3,7 +3,7 @@
 
 Teleport a player forward in the direction they're facing (Like AotE)
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: transmission
   args:

--- a/docs/effects/all-effects/trigger_custom.md
+++ b/docs/effects/all-effects/trigger_custom.md
@@ -3,7 +3,7 @@
 
 Call a custom trigger
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: trigger_custom
   args:

--- a/docs/effects/all-effects/underwater_mining_speed_multiplier.md
+++ b/docs/effects/all-effects/underwater_mining_speed_multiplier.md
@@ -5,7 +5,7 @@ Multiplies underwater mining speed
 
 **Requires 1.21+**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: underwater_mining_speed_multiplier
   args:

--- a/docs/effects/all-effects/update_boss_bar.md
+++ b/docs/effects/all-effects/update_boss_bar.md
@@ -3,7 +3,7 @@
 
 Updates a boss bar
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: update_boss_bar
   args:

--- a/docs/effects/all-effects/victim_speed_multiplier.md
+++ b/docs/effects/all-effects/victim_speed_multiplier.md
@@ -3,7 +3,7 @@
 
 Temporarily multiplies victim movement speed
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: victim_speed_multiplier
   args:

--- a/docs/effects/all-effects/water_movement_efficiency_multiplier.md
+++ b/docs/effects/all-effects/water_movement_efficiency_multiplier.md
@@ -5,7 +5,7 @@ Multiplies water movement efficiency
 
 **Requires 1.21+**
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: water_movement_efficiency_multiplier
   args:

--- a/docs/effects/all-effects/xp_multiplier.md
+++ b/docs/effects/all-effects/xp_multiplier.md
@@ -3,7 +3,7 @@
 
 Multiplies incoming xp gain
 
-# Example Config
+# Effect Syntax
 ```yaml
 - id: xp_multiplier
   args:

--- a/docs/effects/all-filters/above_health_percent.md
+++ b/docs/effects/all-filters/above_health_percent.md
@@ -2,7 +2,7 @@
 
 If the victim must be above a certain percentage of their health 
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   above_health_percent: 50

--- a/docs/effects/all-filters/advancements.md
+++ b/docs/effects/all-filters/advancements.md
@@ -4,7 +4,7 @@ The list of advancements that the effect should activate against
 
 A list of advancement keys can be found [here](https://minecraft.fandom.com/wiki/Advancement)
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   advancements:

--- a/docs/effects/all-filters/alt_value_above.md
+++ b/docs/effects/all-filters/alt_value_above.md
@@ -2,7 +2,7 @@
 
 Require the trigger alt-value to be greater than or equal to a certain amount
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   alt_value_above: 0.5

--- a/docs/effects/all-filters/alt_value_below.md
+++ b/docs/effects/all-filters/alt_value_below.md
@@ -2,7 +2,7 @@
 
 Require the trigger alt-value to be less than a certain amount
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   alt_value_below: 0.5

--- a/docs/effects/all-filters/alt_value_equals.md
+++ b/docs/effects/all-filters/alt_value_equals.md
@@ -2,7 +2,7 @@
 
 Require the trigger alt-value to equal a certain value
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   alt_value_equals: 3

--- a/docs/effects/all-filters/at_war_with_victim.md
+++ b/docs/effects/all-filters/at_war_with_victim.md
@@ -3,7 +3,7 @@
 Requires the player is in a declared war with the victim
 
 **Requires Lands**
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   at_war_with_victim: true

--- a/docs/effects/all-filters/battlepass_reward.md
+++ b/docs/effects/all-filters/battlepass_reward.md
@@ -3,7 +3,7 @@
 The list of battlepass rewards the effect should activate on
 
 **Requires xBattlepass**
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   battlepass_reward: 

--- a/docs/effects/all-filters/battlepass_task.md
+++ b/docs/effects/all-filters/battlepass_task.md
@@ -3,7 +3,7 @@
 The list of battlepass rewards the effect should activate on
 
 **Requires xBattlepass**
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   battlepass_task: 

--- a/docs/effects/all-filters/blocks.md
+++ b/docs/effects/all-filters/blocks.md
@@ -2,7 +2,7 @@
 
 The list of materials (block types) that the effect should activate on
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   blocks: 

--- a/docs/effects/all-filters/custom_crop_stage.md
+++ b/docs/effects/all-filters/custom_crop_stage.md
@@ -3,7 +3,7 @@
 The list of crop stages the effect should activate on
 
 **Requires CustomCrops**
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   custom_crop_stage: 

--- a/docs/effects/all-filters/custom_crop_type.md
+++ b/docs/effects/all-filters/custom_crop_type.md
@@ -3,7 +3,7 @@
 The list of crop types the effect should activate on
 
 **Requires CustomCrops**
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   custom_crop_type: 

--- a/docs/effects/all-filters/custom_fish_type.md
+++ b/docs/effects/all-filters/custom_fish_type.md
@@ -3,7 +3,7 @@
 The list of fish types the effect should activate on
 
 **Requires CustomFishing**
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   custom_fish_type: 

--- a/docs/effects/all-filters/damage_cause.md
+++ b/docs/effects/all-filters/damage_cause.md
@@ -3,7 +3,7 @@
 The list of [damage causes](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html) (incoming out outgoing) that the effect should activate on
 
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   damage_cause:

--- a/docs/effects/all-filters/enchant.md
+++ b/docs/effects/all-filters/enchant.md
@@ -2,7 +2,7 @@
 
 The list of enchants that the `enchant_item` trigger should activate against
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   enchant: 

--- a/docs/effects/all-filters/entities.md
+++ b/docs/effects/all-filters/entities.md
@@ -2,7 +2,7 @@
 
 The list of [entities](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html) that the effect should activate against
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   entities: 

--- a/docs/effects/all-filters/envoy_type.md
+++ b/docs/effects/all-filters/envoy_type.md
@@ -4,7 +4,7 @@ The list of envoy types that the effect should activate against
 
 **Requires AxEnvoy**
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   envoy_type:

--- a/docs/effects/all-filters/fertilizer_type.md
+++ b/docs/effects/all-filters/fertilizer_type.md
@@ -3,7 +3,7 @@
 The list of fertilizers the effect should activate on
 
 **Requires CustomCrops**
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   fertilizer_type: 

--- a/docs/effects/all-filters/from_spawner.md
+++ b/docs/effects/all-filters/from_spawner.md
@@ -2,7 +2,7 @@
 
 If the entity should / should not be from a spawner
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   from_spawner: true

--- a/docs/effects/all-filters/fully_charged.md
+++ b/docs/effects/all-filters/fully_charged.md
@@ -2,7 +2,7 @@
 
 Require the attack to be fully charged (works with melee and bow attacks)
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   fully_charged: true

--- a/docs/effects/all-filters/fully_grown.md
+++ b/docs/effects/all-filters/fully_grown.md
@@ -2,7 +2,7 @@
 
 Require the block to be fully grown
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   fully_grown: true

--- a/docs/effects/all-filters/honey_level_full.md
+++ b/docs/effects/all-filters/honey_level_full.md
@@ -2,7 +2,7 @@
 
 If the beehive or bee nest should be full of honey (honey_level 5)
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   honey_level_full: true

--- a/docs/effects/all-filters/is_behind_victim.md
+++ b/docs/effects/all-filters/is_behind_victim.md
@@ -2,7 +2,7 @@
 
 Require the player to be behind their victim
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   is_behind_victim: true

--- a/docs/effects/all-filters/is_boss.md
+++ b/docs/effects/all-filters/is_boss.md
@@ -2,7 +2,7 @@
 
 If the entity must be a boss
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   is_boss: true

--- a/docs/effects/all-filters/is_expression_true.md
+++ b/docs/effects/all-filters/is_expression_true.md
@@ -2,7 +2,7 @@
 
 Requires a certain expression to be true
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   is_expression_true: "%level% > %victim_health%"

--- a/docs/effects/all-filters/is_npc.md
+++ b/docs/effects/all-filters/is_npc.md
@@ -2,7 +2,7 @@
 
 Require the victim to be an NPC
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   is_npc: true

--- a/docs/effects/all-filters/is_passive.md
+++ b/docs/effects/all-filters/is_passive.md
@@ -2,7 +2,7 @@
 
 If the entity must be passive
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   is_passive: true

--- a/docs/effects/all-filters/item_durability_above.md
+++ b/docs/effects/all-filters/item_durability_above.md
@@ -2,7 +2,7 @@
 
 Requires the item durability to be greater than or equal to a certain amount
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   item_durability_above: 50

--- a/docs/effects/all-filters/item_durability_above_percent.md
+++ b/docs/effects/all-filters/item_durability_above_percent.md
@@ -2,7 +2,7 @@
 
 Requires the item durability to be greater than or equal to a certain percentage
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   item_durability_above_percent: 50

--- a/docs/effects/all-filters/item_durability_below.md
+++ b/docs/effects/all-filters/item_durability_below.md
@@ -2,7 +2,7 @@
 
 Requires the item durability to be less than or equal to a certain amount
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   item_durability_below: 30

--- a/docs/effects/all-filters/item_durability_below_percent.md
+++ b/docs/effects/all-filters/item_durability_below_percent.md
@@ -2,7 +2,7 @@
 
 Requires the item durability to be less than or equal to a certain percentage
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   item_durability_below_percent: 10

--- a/docs/effects/all-filters/items.md
+++ b/docs/effects/all-filters/items.md
@@ -2,7 +2,7 @@
 
 Requires the [item(s)](https://plugins.auxilor.io/all-plugins/the-item-lookup-system) provided to be in a certain set of items
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   items: 

--- a/docs/effects/all-filters/job.md
+++ b/docs/effects/all-filters/job.md
@@ -4,7 +4,7 @@ Require a certain job
 
 **Requires EcoJobs**
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   job:

--- a/docs/effects/all-filters/magic_type.md
+++ b/docs/effects/all-filters/magic_type.md
@@ -4,7 +4,7 @@ Require a certain magic type
 
 **Requires EcoSkills**
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   magic_type:

--- a/docs/effects/all-filters/mcmmo_ability.md
+++ b/docs/effects/all-filters/mcmmo_ability.md
@@ -2,7 +2,7 @@
 
 The list of [entities](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html) that the effect should activate against
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   mcmmo_ability: 

--- a/docs/effects/all-filters/npc.md
+++ b/docs/effects/all-filters/npc.md
@@ -4,7 +4,7 @@ Require a certain NPC
 
 **Requires Citizens || FancyNpcs**
 
-# Example Config
+# Filter Syntax
 
 **Citizens**
 ```yaml

--- a/docs/effects/all-filters/on_max_health.md
+++ b/docs/effects/all-filters/on_max_health.md
@@ -2,7 +2,7 @@
 
 If the victim must be on max health
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   on_max_health: true

--- a/docs/effects/all-filters/pet.md
+++ b/docs/effects/all-filters/pet.md
@@ -4,7 +4,7 @@ Require a certain pet
 
 **Requires EcoPets**
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   pet:

--- a/docs/effects/all-filters/player_name.md
+++ b/docs/effects/all-filters/player_name.md
@@ -2,7 +2,7 @@
 
 Require the player to have a certain name, useful to whitelist admins/etc
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   player_name: 

--- a/docs/effects/all-filters/player_placed.md
+++ b/docs/effects/all-filters/player_placed.md
@@ -2,7 +2,7 @@
 
 If the block must be (or must not be) placed by a player
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   player_placed: false

--- a/docs/effects/all-filters/potion_effect.md
+++ b/docs/effects/all-filters/potion_effect.md
@@ -3,7 +3,7 @@
 The list of [potion effects](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionEffectType.html) that the effect should activate on
 
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   potion_effect: # The list of potion effects

--- a/docs/effects/all-filters/projectiles.md
+++ b/docs/effects/all-filters/projectiles.md
@@ -2,7 +2,7 @@
 
 The list of [projectiles](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/Projectile.html) that the effect should activate with
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   projectiles: 

--- a/docs/effects/all-filters/quest.md
+++ b/docs/effects/all-filters/quest.md
@@ -4,7 +4,7 @@ Require a certain quest
 
 **Requires EcoQuests**
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   quest:

--- a/docs/effects/all-filters/region.md
+++ b/docs/effects/all-filters/region.md
@@ -4,7 +4,7 @@ Require a certain region
 
 **Requires WorldGuard**
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   region:

--- a/docs/effects/all-filters/scroll.md
+++ b/docs/effects/all-filters/scroll.md
@@ -4,7 +4,7 @@ Require a certain scroll
 
 **Requires EcoScrolls**
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   scroll:

--- a/docs/effects/all-filters/sheep_color.md
+++ b/docs/effects/all-filters/sheep_color.md
@@ -2,7 +2,7 @@
 
 Requires the sheep to be a certain color
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   sheep_color:

--- a/docs/effects/all-filters/shop_item.md
+++ b/docs/effects/all-filters/shop_item.md
@@ -4,7 +4,7 @@ Require a certain shop item
 
 **Requires EcoShop**
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   shop_item:

--- a/docs/effects/all-filters/skill.md
+++ b/docs/effects/all-filters/skill.md
@@ -4,7 +4,7 @@ Require a certain skill
 
 **Requires EcoSkills or McMMO**
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   skill:

--- a/docs/effects/all-filters/spawner_entity.md
+++ b/docs/effects/all-filters/spawner_entity.md
@@ -2,7 +2,7 @@
 
 The list of the types of [mobs](https://plugins.auxilor.io/all-plugins/the-entity-lookup-system) within a spawner that the effect should activate on
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   spawner_entity: 

--- a/docs/effects/all-filters/swept.md
+++ b/docs/effects/all-filters/swept.md
@@ -2,7 +2,7 @@
 
 If melee damage was the result of a sweeping attack
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   swept: true

--- a/docs/effects/all-filters/task.md
+++ b/docs/effects/all-filters/task.md
@@ -4,7 +4,7 @@ Require a certain task
 
 **Requires EcoQuests**
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   task:

--- a/docs/effects/all-filters/text.md
+++ b/docs/effects/all-filters/text.md
@@ -2,7 +2,7 @@
 
 The list of text that the trigger has to match at least one of
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   text: 

--- a/docs/effects/all-filters/text_contains.md
+++ b/docs/effects/all-filters/text_contains.md
@@ -2,7 +2,7 @@
 
 The list of text that the trigger has to match at least one of
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   text_contains: 

--- a/docs/effects/all-filters/this_item.md
+++ b/docs/effects/all-filters/this_item.md
@@ -2,7 +2,7 @@
 
 Requires the item provided to be the same as the item that has the effects (e.g., the EcoItem or the enchanted item)
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   this_item: true 

--- a/docs/effects/all-filters/town_role.md
+++ b/docs/effects/all-filters/town_role.md
@@ -3,7 +3,7 @@
 The list of town roles the effect should activate on
 
 **Requires HuskTowns**
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   town_role: 

--- a/docs/effects/all-filters/value_above.md
+++ b/docs/effects/all-filters/value_above.md
@@ -2,7 +2,7 @@
 
 Require the trigger value to be greater than or equal to a certain amount
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   value_above: 0.5

--- a/docs/effects/all-filters/value_below.md
+++ b/docs/effects/all-filters/value_below.md
@@ -2,7 +2,7 @@
 
 Require the trigger value to be less than a certain amount
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   value_below: 0.5

--- a/docs/effects/all-filters/value_equals.md
+++ b/docs/effects/all-filters/value_equals.md
@@ -2,7 +2,7 @@
 
 Require the trigger value to equal a certain value
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   value_equals: 3

--- a/docs/effects/all-filters/victim_conditions.md
+++ b/docs/effects/all-filters/victim_conditions.md
@@ -2,7 +2,7 @@
 
 Check conditions against the victim
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   victim_conditions: # List of conditions to check

--- a/docs/effects/all-filters/victim_name.md
+++ b/docs/effects/all-filters/victim_name.md
@@ -2,7 +2,7 @@
 
 Require the victim to have a certain name
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   victim_name: 

--- a/docs/effects/all-filters/vote_service.md
+++ b/docs/effects/all-filters/vote_service.md
@@ -4,7 +4,7 @@ The list of vote services that the effect should activate on
 
 **Requires NuVotifier**
 
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   vote_service:

--- a/docs/effects/all-filters/watering_can_type.md
+++ b/docs/effects/all-filters/watering_can_type.md
@@ -3,7 +3,7 @@
 The list of watering cans the effect should activate on
 
 **Requires CustomCrops**
-# Example Config
+# Filter Syntax
 ```yaml
 filters:
   watering_can_type: 

--- a/docs/effects/all-mutators/block_to_location.md
+++ b/docs/effects/all-mutators/block_to_location.md
@@ -2,7 +2,7 @@
 
 Set the block to be the block at the location
 
-# Example Config
+# Mutator Syntax
 ```yaml
 - id: block_to_location
 ```

--- a/docs/effects/all-mutators/dispatcher_as_player.md
+++ b/docs/effects/all-mutators/dispatcher_as_player.md
@@ -2,7 +2,7 @@
 
 Set the player to be whoever dispatched (triggered) the effect.
 
-# Example Config
+# Mutator Syntax
 ```yaml
 - id: dispatcher_as_player
 ```

--- a/docs/effects/all-mutators/dispatcher_as_victim.md
+++ b/docs/effects/all-mutators/dispatcher_as_victim.md
@@ -2,7 +2,7 @@
 
 Set the victim to be whoever dispatched (triggered) the effect.
 
-# Example Config
+# Mutator Syntax
 ```yaml
 - id: dispatcher_as_victim
 ```

--- a/docs/effects/all-mutators/location_to_block.md
+++ b/docs/effects/all-mutators/location_to_block.md
@@ -2,7 +2,7 @@
 
 Move the location to the block's location
 
-# Example Config
+# Mutator Syntax
 ```yaml
 - id: location_to_block
 ```

--- a/docs/effects/all-mutators/location_to_cursor.md
+++ b/docs/effects/all-mutators/location_to_cursor.md
@@ -2,7 +2,7 @@
 
 Move the location to where you or the victim are looking
 
-# Example Config
+# Mutator Syntax
 ```yaml
 - id: location_to_cursor
   args:

--- a/docs/effects/all-mutators/location_to_drop.md
+++ b/docs/effects/all-mutators/location_to_drop.md
@@ -2,7 +2,7 @@
 
 Move the location to the drop location
 
-# Example Config
+# Mutator Syntax
 ```yaml
 - id: location_to_drop
 ```

--- a/docs/effects/all-mutators/location_to_player.md
+++ b/docs/effects/all-mutators/location_to_player.md
@@ -2,7 +2,7 @@
 
 Move the location to the player's location
 
-# Example Config
+# Mutator Syntax
 ```yaml
 - id: location_to_player
 ```

--- a/docs/effects/all-mutators/location_to_projectile.md
+++ b/docs/effects/all-mutators/location_to_projectile.md
@@ -2,7 +2,7 @@
 
 Move the location to the projectile's location
 
-# Example Config
+# Mutator Syntax
 ```yaml
 - id: location_to_projectile
 ```

--- a/docs/effects/all-mutators/location_to_victim.md
+++ b/docs/effects/all-mutators/location_to_victim.md
@@ -2,7 +2,7 @@
 
 Move the location to the victim's location
 
-# Example Config
+# Mutator Syntax
 ```yaml
 - id: location_to_victim
 ```

--- a/docs/effects/all-mutators/player_as_victim.md
+++ b/docs/effects/all-mutators/player_as_victim.md
@@ -2,7 +2,7 @@
 
 Marks the player as the victim, useful to have negative effects
 
-# Example Config
+# Mutator Syntax
 ```yaml
 - id: player_as_victim
 ```

--- a/docs/effects/all-mutators/spin_location.md
+++ b/docs/effects/all-mutators/spin_location.md
@@ -2,7 +2,7 @@
 
 Spin a location a certain angle with a radius away from its current position - for example spinning the location 90 degrees at a distance of 1 block
 
-# Example Config
+# Mutator Syntax
 ```yaml
 - id: spin_location
   args:

--- a/docs/effects/all-mutators/spin_velocity.md
+++ b/docs/effects/all-mutators/spin_velocity.md
@@ -2,7 +2,7 @@
 
 Rotate a velocity around the y axis
 
-# Example Config
+# Mutator Syntax
 ```yaml
 - id: spin_velocity
   args:

--- a/docs/effects/all-mutators/translate_location.md
+++ b/docs/effects/all-mutators/translate_location.md
@@ -2,7 +2,7 @@
 
 Translate the location by specified x, y, and z values
 
-# Example Config
+# Mutator Syntax
 ```yaml
 - id: translate_location
   args:

--- a/docs/effects/all-mutators/victim_as_dispatcher.md
+++ b/docs/effects/all-mutators/victim_as_dispatcher.md
@@ -4,7 +4,7 @@ Set the player / entity / etc that triggered the effect to be the victim.
 
 Use this if you want to make a victim run a chain.
 
-# Example Config
+# Mutator Syntax
 ```yaml
 - id: victim_as_dispatcher
 ```

--- a/docs/effects/all-mutators/victim_as_player.md
+++ b/docs/effects/all-mutators/victim_as_player.md
@@ -2,7 +2,7 @@
 
 Set the player to be the victim - useful to give the victim items, etc. Only works when the victim is a player.
 
-# Example Config
+# Mutator Syntax
 ```yaml
 - id: victim_as_player
 ```

--- a/docs/effects/all-mutators/victim_to_owner.md
+++ b/docs/effects/all-mutators/victim_to_owner.md
@@ -2,7 +2,7 @@
 
 If the victim is a tamed animal, set the victim to be the owner of the animal
 
-# Example Config
+# Mutator Syntax
 ```yaml
 - id: victim_to_owner
 ```


### PR DESCRIPTION
Updated documentation for all condition effect markdown files to use the heading 'Condition Syntax' instead of 'Example Config' for improved clarity and consistency.