### PR TITLE
Update effect docs to use new callout syntax

### DIFF
--- a/docs/effects/all-effects/add_damage.md
+++ b/docs/effects/all-effects/add_damage.md
@@ -1,5 +1,6 @@
 # `add_damage`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Adds incoming or outgoing damage from any damage trigger
 

--- a/docs/effects/all-effects/add_durability.md
+++ b/docs/effects/all-effects/add_durability.md
@@ -1,5 +1,6 @@
 # `add_durability`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Increase the max durability of an item
 

--- a/docs/effects/all-effects/add_enchant.md
+++ b/docs/effects/all-effects/add_enchant.md
@@ -1,5 +1,6 @@
 # `add_enchant`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Adds an enchant to the item
 

--- a/docs/effects/all-effects/add_global_points.md
+++ b/docs/effects/all-effects/add_global_points.md
@@ -1,5 +1,6 @@
 # `add_global_points`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Add / subtract global points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 

--- a/docs/effects/all-effects/add_holder.md
+++ b/docs/effects/all-effects/add_holder.md
@@ -1,5 +1,6 @@
 # `add_holder`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives a custom holder temporarily for a given period of time
 

--- a/docs/effects/all-effects/add_holder_in_radius.md
+++ b/docs/effects/all-effects/add_holder_in_radius.md
@@ -1,5 +1,6 @@
 # `add_holder_in_radius`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives a custom holder temporarily for a given period of time
 

--- a/docs/effects/all-effects/add_holder_to_victim.md
+++ b/docs/effects/all-effects/add_holder_to_victim.md
@@ -1,5 +1,6 @@
 # `add_holder_to_victim`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives a custom holder temporarily to your victim (they must be a player) for a given period of time
 

--- a/docs/effects/all-effects/add_permanent_holder_in_radius.md
+++ b/docs/effects/all-effects/add_permanent_holder_in_radius.md
@@ -1,5 +1,6 @@
 # `add_permanent_holder_in_radius`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Gives a custom holder to people within a certain radius of you.
 

--- a/docs/effects/all-effects/add_points.md
+++ b/docs/effects/all-effects/add_points.md
@@ -1,5 +1,6 @@
 # `add_points`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Add / subtract points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 

--- a/docs/effects/all-effects/add_stat.md
+++ b/docs/effects/all-effects/add_stat.md
@@ -1,5 +1,6 @@
 # `add_stat`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Adds a value to a specific stat
 

--- a/docs/effects/all-effects/add_stat_temporarily.md
+++ b/docs/effects/all-effects/add_stat_temporarily.md
@@ -1,5 +1,6 @@
 # `add_stat_temporarily`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Adds a value to a specific stat
 

--- a/docs/effects/all-effects/age_crop.md
+++ b/docs/effects/all-effects/age_crop.md
@@ -1,5 +1,6 @@
 # `age_crop`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 If the block is a crop, age it by a certain amount
 

--- a/docs/effects/all-effects/all_players.md
+++ b/docs/effects/all-effects/all_players.md
@@ -1,5 +1,6 @@
 # `all_players`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Runs effects for all players on the server
 

--- a/docs/effects/all-effects/animation.md
+++ b/docs/effects/all-effects/animation.md
@@ -1,6 +1,7 @@
 # `animation`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Plays an animation
 

--- a/docs/effects/all-effects/aoe.md
+++ b/docs/effects/all-effects/aoe.md
@@ -1,6 +1,7 @@
 # `aoe`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Runs effects for all entities within an area of effect (aoe)
 

--- a/docs/effects/all-effects/aoe_blocks.md
+++ b/docs/effects/all-effects/aoe_blocks.md
@@ -1,6 +1,7 @@
 # `aoe_blocks`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Runs effects for all blocks within an area of effect
 

--- a/docs/effects/all-effects/armor.md
+++ b/docs/effects/all-effects/armor.md
@@ -1,5 +1,6 @@
 # `armor`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Gives armor points
 

--- a/docs/effects/all-effects/armor_toughness.md
+++ b/docs/effects/all-effects/armor_toughness.md
@@ -1,5 +1,6 @@
 # `armor_toughness`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Gives armor toughness
 

--- a/docs/effects/all-effects/arrow_ring.md
+++ b/docs/effects/all-effects/arrow_ring.md
@@ -1,5 +1,6 @@
 # `arrow_ring`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Spawns a ring of arrows around a location
 

--- a/docs/effects/all-effects/attack_speed_multiplier.md
+++ b/docs/effects/all-effects/attack_speed_multiplier.md
@@ -1,5 +1,6 @@
 # `attack_speed_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies attack speed
 

--- a/docs/effects/all-effects/autosmelt.md
+++ b/docs/effects/all-effects/autosmelt.md
@@ -1,5 +1,6 @@
 # `autosmelt`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Autosmelts drops (requires a drop trigger)
 

--- a/docs/effects/all-effects/battlepass_task_xp_multiplier.md
+++ b/docs/effects/all-effects/battlepass_task_xp_multiplier.md
@@ -1,5 +1,6 @@
 # `battlepass_task_xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies incoming battlepass task xp gain
 

--- a/docs/effects/all-effects/battlepass_xp_multiplier.md
+++ b/docs/effects/all-effects/battlepass_xp_multiplier.md
@@ -1,5 +1,6 @@
 # `battlepass_xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies incoming battlepass xp gain
 

--- a/docs/effects/all-effects/bleed.md
+++ b/docs/effects/all-effects/bleed.md
@@ -1,5 +1,6 @@
 # `bleed`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Makes your victim bleed, damaging them repeatedly
 

--- a/docs/effects/all-effects/block_commands.md
+++ b/docs/effects/all-effects/block_commands.md
@@ -1,5 +1,6 @@
 # `block_commands`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Prevents the execution of certain commands
 

--- a/docs/effects/all-effects/block_reach.md
+++ b/docs/effects/all-effects/block_reach.md
@@ -1,5 +1,6 @@
 # `block_reach`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Adds reach for interacting with blocks
 

--- a/docs/effects/all-effects/bonus_health.md
+++ b/docs/effects/all-effects/bonus_health.md
@@ -1,5 +1,6 @@
 # `bonus_health`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Gives extra health
 

--- a/docs/effects/all-effects/break_block.md
+++ b/docs/effects/all-effects/break_block.md
@@ -1,5 +1,6 @@
 # `break_block`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Breaks a block instantly
 

--- a/docs/effects/all-effects/brew_time_multiplier.md
+++ b/docs/effects/all-effects/brew_time_multiplier.md
@@ -1,5 +1,6 @@
 # `brew_time_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies the time taken to brew potions
 

--- a/docs/effects/all-effects/broadcast.md
+++ b/docs/effects/all-effects/broadcast.md
@@ -1,5 +1,6 @@
 # `broadcast`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Send a message to everyone online
 

--- a/docs/effects/all-effects/burning_time_multiplier.md
+++ b/docs/effects/all-effects/burning_time_multiplier.md
@@ -1,5 +1,6 @@
 # `burning_time_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies how long an entity is on fire after being ignited
 

--- a/docs/effects/all-effects/cancel_event.md
+++ b/docs/effects/all-effects/cancel_event.md
@@ -1,5 +1,6 @@
 # `cancel_event`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Cancel the event that fired the trigger
 

--- a/docs/effects/all-effects/clear_invulnerability.md
+++ b/docs/effects/all-effects/clear_invulnerability.md
@@ -1,6 +1,7 @@
 # `clear_invulnerability`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Removes the victim's invulnerability frame
 

--- a/docs/effects/all-effects/close_inventory.md
+++ b/docs/effects/all-effects/close_inventory.md
@@ -1,5 +1,6 @@
 # `close_inventory`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Closes the player's inventory
 

--- a/docs/effects/all-effects/consume_held_item.md
+++ b/docs/effects/all-effects/consume_held_item.md
@@ -1,5 +1,6 @@
 # `consume_held_item`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Consume items held in the player's main hand
 

--- a/docs/effects/all-effects/create_boss_bar.md
+++ b/docs/effects/all-effects/create_boss_bar.md
@@ -1,5 +1,6 @@
 # `create_boss_bar`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Creates a boss bar and shows it to the player
 

--- a/docs/effects/all-effects/create_explosion.md
+++ b/docs/effects/all-effects/create_explosion.md
@@ -1,5 +1,6 @@
 # `create_explosion`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Creates an explosion
 

--- a/docs/effects/all-effects/create_hologram.md
+++ b/docs/effects/all-effects/create_hologram.md
@@ -1,6 +1,7 @@
 # `create_hologram`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Creates a hologram temporarily (Requires a hologram plugin to be installed)
 

--- a/docs/effects/all-effects/crit_multiplier.md
+++ b/docs/effects/all-effects/crit_multiplier.md
@@ -1,5 +1,6 @@
 # `crit_multiplier`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Multiplies critical (falling) hit damage
 

--- a/docs/effects/all-effects/damage_armor.md
+++ b/docs/effects/all-effects/damage_armor.md
@@ -1,5 +1,6 @@
 # `damage_armor`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Damage a victim's armor
 

--- a/docs/effects/all-effects/damage_item.md
+++ b/docs/effects/all-effects/damage_item.md
@@ -1,5 +1,6 @@
 # `damage_item`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Damages the item
 

--- a/docs/effects/all-effects/damage_mainhand.md
+++ b/docs/effects/all-effects/damage_mainhand.md
@@ -1,5 +1,6 @@
 # `damage_mainhand`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Damage a victim's mainhand item
 

--- a/docs/effects/all-effects/damage_multiplier.md
+++ b/docs/effects/all-effects/damage_multiplier.md
@@ -1,5 +1,6 @@
 # `damage_multiplier`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Multiplies incoming or outgoing damage from any damage trigger
 

--- a/docs/effects/all-effects/damage_nearby_entities.md
+++ b/docs/effects/all-effects/damage_nearby_entities.md
@@ -1,5 +1,6 @@
 # `damage_nearby_entities`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Damage entities near a location
 

--- a/docs/effects/all-effects/damage_offhand.md
+++ b/docs/effects/all-effects/damage_offhand.md
@@ -1,5 +1,6 @@
 # `damage_offhand`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Damage a victim's offhand item
 

--- a/docs/effects/all-effects/damage_twice.md
+++ b/docs/effects/all-effects/damage_twice.md
@@ -1,5 +1,6 @@
 # `damage_twice`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Deals an extra hit to the victim
 

--- a/docs/effects/all-effects/damage_victim.md
+++ b/docs/effects/all-effects/damage_victim.md
@@ -1,5 +1,6 @@
 # `damage_victim`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Damage the victim
 

--- a/docs/effects/all-effects/dont_consume_lapis_chance.md
+++ b/docs/effects/all-effects/dont_consume_lapis_chance.md
@@ -1,5 +1,6 @@
 # `dont_consume_lapis_chance`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Prevents consuming lapis when enchanting items
 

--- a/docs/effects/all-effects/dont_consume_xp_chance.md
+++ b/docs/effects/all-effects/dont_consume_xp_chance.md
@@ -1,5 +1,6 @@
 # `dont_consume_xp_chance`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Prevents consuming xp when enchanting items
 

--- a/docs/effects/all-effects/drill.md
+++ b/docs/effects/all-effects/drill.md
@@ -1,5 +1,6 @@
 # `drill`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Mine blocks behind the initial mined block
 

--- a/docs/effects/all-effects/drop_item.md
+++ b/docs/effects/all-effects/drop_item.md
@@ -1,5 +1,6 @@
 # `drop_item`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Drops an item at a location
 

--- a/docs/effects/all-effects/drop_item_slot.md
+++ b/docs/effects/all-effects/drop_item_slot.md
@@ -1,5 +1,6 @@
 # `drop_item_slot`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Drops items from the player's inventory
 

--- a/docs/effects/all-effects/drop_pickup_item.md
+++ b/docs/effects/all-effects/drop_pickup_item.md
@@ -1,6 +1,7 @@
 # `drop_pickup_item`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Drops an item that runs a chain on pickup
 

--- a/docs/effects/all-effects/drop_random_item.md
+++ b/docs/effects/all-effects/drop_random_item.md
@@ -1,5 +1,6 @@
 # `drop_random_item`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Drops a random item at a location
 

--- a/docs/effects/all-effects/drop_weighted_random_item.md
+++ b/docs/effects/all-effects/drop_weighted_random_item.md
@@ -1,5 +1,6 @@
 # `drop_weighted_random_item`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Drops a random item at a location, with weighting for different items
 

--- a/docs/effects/all-effects/elytra_boost_save_chance.md
+++ b/docs/effects/all-effects/elytra_boost_save_chance.md
@@ -1,5 +1,6 @@
 # `elytra_boost_save_chance`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Prevents consuming fireworks when boosting with an elytra
 

--- a/docs/effects/all-effects/entity_reach.md
+++ b/docs/effects/all-effects/entity_reach.md
@@ -1,5 +1,6 @@
 # `entity_reach`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Adds reach for interacting with entities
 

--- a/docs/effects/all-effects/explosion_knockback_resistance_multiplier.md
+++ b/docs/effects/all-effects/explosion_knockback_resistance_multiplier.md
@@ -1,5 +1,6 @@
 # `explosion_knockback_resistance_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies explosion resistance
 

--- a/docs/effects/all-effects/extinguish.md
+++ b/docs/effects/all-effects/extinguish.md
@@ -1,5 +1,6 @@
 # `extinguish`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Extinguish the player
 

--- a/docs/effects/all-effects/feather_step.md
+++ b/docs/effects/all-effects/feather_step.md
@@ -1,5 +1,6 @@
 # `feather_step`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Prevents trampling crops
 

--- a/docs/effects/all-effects/flight.md
+++ b/docs/effects/all-effects/flight.md
@@ -1,5 +1,6 @@
 # `flight`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Grants flight
 

--- a/docs/effects/all-effects/food_multiplier.md
+++ b/docs/effects/all-effects/food_multiplier.md
@@ -1,5 +1,6 @@
 # `food_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies food gain from eating
 

--- a/docs/effects/all-effects/gain_task_xp.md
+++ b/docs/effects/all-effects/gain_task_xp.md
@@ -1,6 +1,7 @@
 # `gain_task_xp`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gains experience points for a task in a quest, including multipliers.
 

--- a/docs/effects/all-effects/give_battlepass_task_xp.md
+++ b/docs/effects/all-effects/give_battlepass_task_xp.md
@@ -1,5 +1,6 @@
 # `give_battlepass_task_xp`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives experience points for a task in a quest, excluding multipliers.
 

--- a/docs/effects/all-effects/give_battlepass_tier.md
+++ b/docs/effects/all-effects/give_battlepass_tier.md
@@ -1,5 +1,6 @@
 # `give_battlepass_tier`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Give battlepass tiers to the player.
 

--- a/docs/effects/all-effects/give_battlepass_xp.md
+++ b/docs/effects/all-effects/give_battlepass_xp.md
@@ -1,5 +1,6 @@
 # `give_battlepass_xp`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Give battlepass experience points
 

--- a/docs/effects/all-effects/give_food.md
+++ b/docs/effects/all-effects/give_food.md
@@ -1,5 +1,6 @@
 # `give_food`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives the player food
 

--- a/docs/effects/all-effects/give_global_points.md
+++ b/docs/effects/all-effects/give_global_points.md
@@ -1,5 +1,6 @@
 # `give_global_points`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Add / subtract global points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 

--- a/docs/effects/all-effects/give_health.md
+++ b/docs/effects/all-effects/give_health.md
@@ -1,5 +1,6 @@
 # `give_health`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives the player health
 

--- a/docs/effects/all-effects/give_item.md
+++ b/docs/effects/all-effects/give_item.md
@@ -1,5 +1,6 @@
 # `give_item`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives a player an item
 

--- a/docs/effects/all-effects/give_item_points.md
+++ b/docs/effects/all-effects/give_item_points.md
@@ -1,5 +1,6 @@
 # `give_item_points`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Add / subtract item points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 

--- a/docs/effects/all-effects/give_job_xp.md
+++ b/docs/effects/all-effects/give_job_xp.md
@@ -1,5 +1,6 @@
 # `give_job_xp`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives experience points for a certain job
 

--- a/docs/effects/all-effects/give_lands_balance.md
+++ b/docs/effects/all-effects/give_lands_balance.md
@@ -1,6 +1,7 @@
 # `give_lands_balance`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Give money to a Land's bank balance
 

--- a/docs/effects/all-effects/give_magic.md
+++ b/docs/effects/all-effects/give_magic.md
@@ -1,5 +1,6 @@
 # `give_magic`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Add / subtract magic
 

--- a/docs/effects/all-effects/give_mcmmo_xp.md
+++ b/docs/effects/all-effects/give_mcmmo_xp.md
@@ -1,5 +1,6 @@
 # `give_mcmmo_xp`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives experience points for a certain skill
 

--- a/docs/effects/all-effects/give_money.md
+++ b/docs/effects/all-effects/give_money.md
@@ -1,5 +1,6 @@
 # `give_money`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives a player money
 

--- a/docs/effects/all-effects/give_oxygen.md
+++ b/docs/effects/all-effects/give_oxygen.md
@@ -1,5 +1,6 @@
 # `give_oxygen`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Give a player oxygen
 

--- a/docs/effects/all-effects/give_permission.md
+++ b/docs/effects/all-effects/give_permission.md
@@ -1,5 +1,6 @@
 # `give_permission`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Gives a permission while active
 

--- a/docs/effects/all-effects/give_pet_xp.md
+++ b/docs/effects/all-effects/give_pet_xp.md
@@ -1,5 +1,6 @@
 # `give_pet_xp`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives experience points for a certain pet
 

--- a/docs/effects/all-effects/give_points.md
+++ b/docs/effects/all-effects/give_points.md
@@ -1,5 +1,6 @@
 # `give_points`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Add / subtract points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 

--- a/docs/effects/all-effects/give_price.md
+++ b/docs/effects/all-effects/give_price.md
@@ -1,5 +1,6 @@
 # `give_price`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Pay a [price](https://plugins.auxilor.io/all-plugins/prices) to a player
 

--- a/docs/effects/all-effects/give_saturation.md
+++ b/docs/effects/all-effects/give_saturation.md
@@ -1,5 +1,6 @@
 # `give_saturation`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives the player saturation
 

--- a/docs/effects/all-effects/give_skill_xp.md
+++ b/docs/effects/all-effects/give_skill_xp.md
@@ -1,5 +1,6 @@
 # `give_skill_xp`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives experience points for a certain skill
 

--- a/docs/effects/all-effects/give_skill_xp_naturally.md
+++ b/docs/effects/all-effects/give_skill_xp_naturally.md
@@ -1,5 +1,6 @@
 # `give_skill_xp_naturally`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives naturally-gained experience points for a certain skill
 

--- a/docs/effects/all-effects/give_task_xp.md
+++ b/docs/effects/all-effects/give_task_xp.md
@@ -1,6 +1,7 @@
 # `give_task_xp`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives experience points for a task in a quest, excluding multipliers.
 

--- a/docs/effects/all-effects/give_xp.md
+++ b/docs/effects/all-effects/give_xp.md
@@ -1,5 +1,6 @@
 # `give_xp`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives experience points
 

--- a/docs/effects/all-effects/glow_nearby_blocks.md
+++ b/docs/effects/all-effects/glow_nearby_blocks.md
@@ -1,5 +1,6 @@
 # `glow_nearby_blocks`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Make nearby blocks of a certain type glow a certain color
 

--- a/docs/effects/all-effects/gravity_multiplier.md
+++ b/docs/effects/all-effects/gravity_multiplier.md
@@ -1,5 +1,6 @@
 # `gravity_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies gravity
 

--- a/docs/effects/all-effects/homing.md
+++ b/docs/effects/all-effects/homing.md
@@ -1,6 +1,7 @@
 # `homing`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Makes projectiles hone in onto entities (homing arrows / tridents)
 

--- a/docs/effects/all-effects/hunger_multiplier.md
+++ b/docs/effects/all-effects/hunger_multiplier.md
@@ -1,5 +1,6 @@
 # `hunger_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies hunger loss
 

--- a/docs/effects/all-effects/ignite.md
+++ b/docs/effects/all-effects/ignite.md
@@ -1,5 +1,6 @@
 # `ignite`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Lights the victim on fire
 

--- a/docs/effects/all-effects/increase_step_height.md
+++ b/docs/effects/all-effects/increase_step_height.md
@@ -1,5 +1,6 @@
 # `increase_step_height`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Increases the amount of blocks you can walk over without jumping
 

--- a/docs/effects/all-effects/inscribe_item.md
+++ b/docs/effects/all-effects/inscribe_item.md
@@ -1,6 +1,7 @@
 # `inscribe_item`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Inscribes an item with a scroll
 

--- a/docs/effects/all-effects/item_durability_multiplier.md
+++ b/docs/effects/all-effects/item_durability_multiplier.md
@@ -1,5 +1,6 @@
 # `item_durability_multiplier`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Multiplies item durability (only works if holders are items, e.g. in EcoEnchants, EcoItems, etc.)
 

--- a/docs/effects/all-effects/job_xp_multiplier.md
+++ b/docs/effects/all-effects/job_xp_multiplier.md
@@ -1,5 +1,6 @@
 # `job_xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies job xp gain
 

--- a/docs/effects/all-effects/jobs_money_multiplier.md
+++ b/docs/effects/all-effects/jobs_money_multiplier.md
@@ -1,5 +1,6 @@
 # `jobs_money_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies money gain from jobs
 

--- a/docs/effects/all-effects/jobs_xp_multiplier.md
+++ b/docs/effects/all-effects/jobs_xp_multiplier.md
@@ -1,5 +1,6 @@
 # `jobs_xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies xp gain from jobs
 

--- a/docs/effects/all-effects/jump_strength_multiplier.md
+++ b/docs/effects/all-effects/jump_strength_multiplier.md
@@ -1,5 +1,6 @@
 # `jump_strength_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies jump strength
 

--- a/docs/effects/all-effects/keep_inventory.md
+++ b/docs/effects/all-effects/keep_inventory.md
@@ -1,5 +1,6 @@
 # `keep_inventory`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Gives the player keep inventory
 

--- a/docs/effects/all-effects/keep_level.md
+++ b/docs/effects/all-effects/keep_level.md
@@ -1,5 +1,6 @@
 # `keep_level`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Makes the player keep their XP level on death
 

--- a/docs/effects/all-effects/kick.md
+++ b/docs/effects/all-effects/kick.md
@@ -1,5 +1,6 @@
 # `kick`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Kicks the player
 

--- a/docs/effects/all-effects/knock_away.md
+++ b/docs/effects/all-effects/knock_away.md
@@ -1,5 +1,6 @@
 # `knock_away`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Knock the victim away from the player
 

--- a/docs/effects/all-effects/knockback_multiplier.md
+++ b/docs/effects/all-effects/knockback_multiplier.md
@@ -1,5 +1,6 @@
 # `knockback_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies attack knockback
 

--- a/docs/effects/all-effects/knockback_resistance_multiplier.md
+++ b/docs/effects/all-effects/knockback_resistance_multiplier.md
@@ -1,5 +1,6 @@
 # `knockback_resistance_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies knockback resistance
 

--- a/docs/effects/all-effects/level_item.md
+++ b/docs/effects/all-effects/level_item.md
@@ -1,5 +1,6 @@
 # `level_item`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gain item XP for a certain level
 

--- a/docs/effects/all-effects/luck_multiplier.md
+++ b/docs/effects/all-effects/luck_multiplier.md
@@ -1,5 +1,6 @@
 # `luck_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies luck
 

--- a/docs/effects/all-effects/magic_regen_multiplier.md
+++ b/docs/effects/all-effects/magic_regen_multiplier.md
@@ -1,5 +1,6 @@
 # `magic_regen_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies magic regeneration
 

--- a/docs/effects/all-effects/make_skill_crit.md
+++ b/docs/effects/all-effects/make_skill_crit.md
@@ -1,5 +1,6 @@
 # `make_skill_crit`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Deal a crit hit
 

--- a/docs/effects/all-effects/mcmmo_xp_multiplier.md
+++ b/docs/effects/all-effects/mcmmo_xp_multiplier.md
@@ -1,5 +1,6 @@
 # `mcmmo_xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies mcMMO skill xp gain
 

--- a/docs/effects/all-effects/mine_radius.md
+++ b/docs/effects/all-effects/mine_radius.md
@@ -1,5 +1,6 @@
 # `mine_radius`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Mines a square radius around a block
 

--- a/docs/effects/all-effects/mine_radius_one_deep.md
+++ b/docs/effects/all-effects/mine_radius_one_deep.md
@@ -1,5 +1,6 @@
 # `mine_radius_one_deep`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Mines a square radius around a block, but only one block deep
 

--- a/docs/effects/all-effects/mine_vein.md
+++ b/docs/effects/all-effects/mine_vein.md
@@ -1,6 +1,7 @@
 # `mine_vein`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Mines a vein of blocks
 

--- a/docs/effects/all-effects/mining_efficiency.md
+++ b/docs/effects/all-effects/mining_efficiency.md
@@ -1,5 +1,6 @@
 # `mining_efficiency`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Adds mining efficiency (mining speed when using the correct tool)
 

--- a/docs/effects/all-effects/mining_speed_multiplier.md
+++ b/docs/effects/all-effects/mining_speed_multiplier.md
@@ -1,5 +1,6 @@
 # `mining_speed_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies mining speed
 

--- a/docs/effects/all-effects/mob_coins_chance_multiplier.md
+++ b/docs/effects/all-effects/mob_coins_chance_multiplier.md
@@ -1,5 +1,6 @@
 # `mob_coins_chance_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies the chance of mobcoins being dropped
 

--- a/docs/effects/all-effects/mob_coins_drop_multiplier.md
+++ b/docs/effects/all-effects/mob_coins_drop_multiplier.md
@@ -1,5 +1,6 @@
 # `mob_coins_drop_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies the mobcoins dropped
 

--- a/docs/effects/all-effects/mob_coins_multiplier.md
+++ b/docs/effects/all-effects/mob_coins_multiplier.md
@@ -1,5 +1,6 @@
 # `mob_coins_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies mob coin drops
 

--- a/docs/effects/all-effects/movement_efficiency_multiplier.md
+++ b/docs/effects/all-effects/movement_efficiency_multiplier.md
@@ -1,5 +1,6 @@
 # `movement_efficiency_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies movement speed through difficult terrain
 

--- a/docs/effects/all-effects/movement_speed_multiplier.md
+++ b/docs/effects/all-effects/movement_speed_multiplier.md
@@ -1,5 +1,6 @@
 # `movement_speed_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies movement speed
 

--- a/docs/effects/all-effects/multiply_all_stats.md
+++ b/docs/effects/all-effects/multiply_all_stats.md
@@ -1,5 +1,6 @@
 # `multiply_all_stats`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies all stats by a specific value
 

--- a/docs/effects/all-effects/multiply_drops.md
+++ b/docs/effects/all-effects/multiply_drops.md
@@ -1,5 +1,6 @@
 # `multiply_drops`
-:::danger[Triggered Effect]:::
+:::dangerTriggered Effect
+:::
 
 Multiplies drops (requires a drop trigger)
 

--- a/docs/effects/all-effects/multiply_global_points.md
+++ b/docs/effects/all-effects/multiply_global_points.md
@@ -1,5 +1,5 @@
 # `multiply_global_points`
-:::danger[Triggered Effect]
+:::dangerTriggered Effect
 :::
 
 Multiply global points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)

--- a/docs/effects/all-effects/multiply_magic.md
+++ b/docs/effects/all-effects/multiply_magic.md
@@ -1,5 +1,6 @@
 # `multiply_magic`
-:::dangerTriggered Effect:::
+:::dangerTriggered Effect
+:::
 
 Multiply magic
 

--- a/docs/effects/all-effects/multiply_points.md
+++ b/docs/effects/all-effects/multiply_points.md
@@ -1,5 +1,6 @@
 # `multiply_points`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Multiply points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)
 

--- a/docs/effects/all-effects/multiply_stat.md
+++ b/docs/effects/all-effects/multiply_stat.md
@@ -1,5 +1,6 @@
 # `multiply_stat`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies a stat by a specific value
 

--- a/docs/effects/all-effects/multiply_stat_temporarily.md
+++ b/docs/effects/all-effects/multiply_stat_temporarily.md
@@ -1,5 +1,6 @@
 # `multiply_stat_temporarily`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Multiplies a stat by a specific value
 

--- a/docs/effects/all-effects/multiply_velocity.md
+++ b/docs/effects/all-effects/multiply_velocity.md
@@ -1,5 +1,6 @@
 # `multiply_velocity`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Multiplies a players velocity
 

--- a/docs/effects/all-effects/name_entity.md
+++ b/docs/effects/all-effects/name_entity.md
@@ -1,5 +1,6 @@
 # `name_entity`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Set the display name of an entity
 

--- a/docs/effects/all-effects/open_crafting.md
+++ b/docs/effects/all-effects/open_crafting.md
@@ -1,6 +1,7 @@
 # `open_crafting`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Opens a crafting table for the player
 

--- a/docs/effects/all-effects/open_ender_chest.md
+++ b/docs/effects/all-effects/open_ender_chest.md
@@ -1,6 +1,7 @@
 # `open_ender_chest`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Opens the player's ender chest
 

--- a/docs/effects/all-effects/particle_animation.md
+++ b/docs/effects/all-effects/particle_animation.md
@@ -1,6 +1,7 @@
 # `particle_animation`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Plays a particle animation
 

--- a/docs/effects/all-effects/particle_line.md
+++ b/docs/effects/all-effects/particle_line.md
@@ -1,5 +1,6 @@
 # `particle_line`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Spawns a line of particles between you and the target location
 

--- a/docs/effects/all-effects/pay_price.md
+++ b/docs/effects/all-effects/pay_price.md
@@ -1,5 +1,6 @@
 # `pay_price`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Pay a [price](https://plugins.auxilor.io/all-plugins/prices)
 

--- a/docs/effects/all-effects/permanent_potion_effect.md
+++ b/docs/effects/all-effects/permanent_potion_effect.md
@@ -1,5 +1,6 @@
 # `permanent_potion_effect`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Gives a permanent [potion effect](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionEffectType.html)
 

--- a/docs/effects/all-effects/pet_xp_multiplier.md
+++ b/docs/effects/all-effects/pet_xp_multiplier.md
@@ -1,5 +1,6 @@
 # `pet_xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies pet xp gain
 

--- a/docs/effects/all-effects/piercing.md
+++ b/docs/effects/all-effects/piercing.md
@@ -1,6 +1,7 @@
 # `piercing`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Makes projectiles pass through other entities (collaterals), like the Piercing enchantment.
 

--- a/docs/effects/all-effects/play_animation.md
+++ b/docs/effects/all-effects/play_animation.md
@@ -1,5 +1,6 @@
 # `play_animation`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Plays a Model Engine animation (The entity must have a custom model active)
 

--- a/docs/effects/all-effects/play_sound.md
+++ b/docs/effects/all-effects/play_sound.md
@@ -1,5 +1,6 @@
 # `play_sound`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Plays a sound to the player
 

--- a/docs/effects/all-effects/potion_duration_multiplier.md
+++ b/docs/effects/all-effects/potion_duration_multiplier.md
@@ -1,5 +1,6 @@
 # `potion_duration_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies the duration of brewed potions
 

--- a/docs/effects/all-effects/potion_effect.md
+++ b/docs/effects/all-effects/potion_effect.md
@@ -1,5 +1,6 @@
 # `potion_effect`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives a [potion](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionEffectType.html) effect
 

--- a/docs/effects/all-effects/pull_in.md
+++ b/docs/effects/all-effects/pull_in.md
@@ -1,5 +1,6 @@
 # `pull_in`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Pull the victim towards the player
 

--- a/docs/effects/all-effects/pull_to_location.md
+++ b/docs/effects/all-effects/pull_to_location.md
@@ -1,5 +1,6 @@
 # `pull_to_location`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Get pulled to a location
 

--- a/docs/effects/all-effects/quest_xp_multiplier.md
+++ b/docs/effects/all-effects/quest_xp_multiplier.md
@@ -1,5 +1,6 @@
 # `quest_xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies quest xp gain
 

--- a/docs/effects/all-effects/random_player.md
+++ b/docs/effects/all-effects/random_player.md
@@ -1,5 +1,6 @@
 # `random_player`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Runs effects for a random player on the server
 

--- a/docs/effects/all-effects/rapid_bows.md
+++ b/docs/effects/all-effects/rapid_bows.md
@@ -1,5 +1,6 @@
 # `rapid_bows`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Allows bows to be shot at full speed without pulling back as far
 

--- a/docs/effects/all-effects/reel_speed_multiplier.md
+++ b/docs/effects/all-effects/reel_speed_multiplier.md
@@ -1,5 +1,6 @@
 # `reel_speed_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies the speed at which you pull in entities and drops with fishing rods
 

--- a/docs/effects/all-effects/regen_multiplier.md
+++ b/docs/effects/all-effects/regen_multiplier.md
@@ -1,5 +1,6 @@
 # `regen_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies regen speed
 

--- a/docs/effects/all-effects/remove_boss_bar.md
+++ b/docs/effects/all-effects/remove_boss_bar.md
@@ -1,5 +1,6 @@
 # `remove_boss_bar`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Removes a boss bar
 

--- a/docs/effects/all-effects/remove_enchant.md
+++ b/docs/effects/all-effects/remove_enchant.md
@@ -1,5 +1,6 @@
 # `remove_enchant`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Removes an enchant from the item
 

--- a/docs/effects/all-effects/remove_item.md
+++ b/docs/effects/all-effects/remove_item.md
@@ -1,5 +1,6 @@
 # `remove_item`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Removes an item from the player's inventory
 

--- a/docs/effects/all-effects/remove_item_data.md
+++ b/docs/effects/all-effects/remove_item_data.md
@@ -1,5 +1,6 @@
 # `remove_item_data`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Remove item data
 

--- a/docs/effects/all-effects/remove_potion_effect.md
+++ b/docs/effects/all-effects/remove_potion_effect.md
@@ -1,5 +1,6 @@
 # `remove_potion_effect`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Removes a potion effect
 

--- a/docs/effects/all-effects/repair_item.md
+++ b/docs/effects/all-effects/repair_item.md
@@ -1,5 +1,6 @@
 # `repair_item`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Repairs the item
 

--- a/docs/effects/all-effects/replace_near.md
+++ b/docs/effects/all-effects/replace_near.md
@@ -1,5 +1,6 @@
 # `replace_near`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Replaces nearby blocks with other blocks
 

--- a/docs/effects/all-effects/replant_crops.md
+++ b/docs/effects/all-effects/replant_crops.md
@@ -1,5 +1,6 @@
 # `replant_crops`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Automatically replants crops
 

--- a/docs/effects/all-effects/rotate.md
+++ b/docs/effects/all-effects/rotate.md
@@ -1,5 +1,6 @@
 # `rotate`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Spin around
 

--- a/docs/effects/all-effects/rotate_victim.md
+++ b/docs/effects/all-effects/rotate_victim.md
@@ -1,5 +1,6 @@
 # `rotate_victim`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Spin the victim around
 

--- a/docs/effects/all-effects/run_chain.md
+++ b/docs/effects/all-effects/run_chain.md
@@ -1,5 +1,6 @@
 # `run_chain`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Execute an effect chain
 

--- a/docs/effects/all-effects/run_command.md
+++ b/docs/effects/all-effects/run_command.md
@@ -1,5 +1,6 @@
 # `run_command`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Runs a command from console
 

--- a/docs/effects/all-effects/run_player_command.md
+++ b/docs/effects/all-effects/run_player_command.md
@@ -1,5 +1,6 @@
 # `run_player_command`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Runs a command as a player
 

--- a/docs/effects/all-effects/safe_fall_distance.md
+++ b/docs/effects/all-effects/safe_fall_distance.md
@@ -1,5 +1,6 @@
 # `safe_fall_distance`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Increases/decreases the distance you can fall without taking damage
 

--- a/docs/effects/all-effects/scale.md
+++ b/docs/effects/all-effects/scale.md
@@ -1,5 +1,6 @@
 # `scale`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies scale
 

--- a/docs/effects/all-effects/sell_items.md
+++ b/docs/effects/all-effects/sell_items.md
@@ -1,5 +1,6 @@
 # `sell_items`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Sells dropped items / item from trigger
 

--- a/docs/effects/all-effects/sell_multiplier.md
+++ b/docs/effects/all-effects/sell_multiplier.md
@@ -1,5 +1,6 @@
 # `sell_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies money gained from selling items
 

--- a/docs/effects/all-effects/send_message.md
+++ b/docs/effects/all-effects/send_message.md
@@ -1,5 +1,6 @@
 # `send_message`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Sends the player a message
 

--- a/docs/effects/all-effects/send_minimessage.md
+++ b/docs/effects/all-effects/send_minimessage.md
@@ -1,5 +1,6 @@
 # `send_minimessage`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Sends the player a minimessage message, supports clickable components, etc.
 

--- a/docs/effects/all-effects/send_title.md
+++ b/docs/effects/all-effects/send_title.md
@@ -1,5 +1,6 @@
 # `send_title`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Send a title/subtitle to the player
 

--- a/docs/effects/all-effects/set_armor_trim.md
+++ b/docs/effects/all-effects/set_armor_trim.md
@@ -1,5 +1,6 @@
 # `set_armor_trim`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Sets item armor trim
 

--- a/docs/effects/all-effects/set_battlepass_tier.md
+++ b/docs/effects/all-effects/set_battlepass_tier.md
@@ -1,5 +1,6 @@
 # `set_battlepass_tier`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Set the player's battlepass tier
 

--- a/docs/effects/all-effects/set_block.md
+++ b/docs/effects/all-effects/set_block.md
@@ -1,6 +1,7 @@
 # `set_block`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Set a block
 

--- a/docs/effects/all-effects/set_custom_model_data.md
+++ b/docs/effects/all-effects/set_custom_model_data.md
@@ -1,5 +1,6 @@
 # `set_custom_model_data`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Set the item's custom model data
 

--- a/docs/effects/all-effects/set_food.md
+++ b/docs/effects/all-effects/set_food.md
@@ -1,5 +1,6 @@
 # `set_food`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Sets the player's food
 

--- a/docs/effects/all-effects/set_freeze_ticks.md
+++ b/docs/effects/all-effects/set_freeze_ticks.md
@@ -1,5 +1,6 @@
 # `set_freeze_ticks`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Sets the victims freeze ticks (frost / powdered snow effect)
 

--- a/docs/effects/all-effects/set_global_points.md
+++ b/docs/effects/all-effects/set_global_points.md
@@ -1,5 +1,6 @@
 # `set_global_points`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Set global points (check the points wiki page if you don't know what these are)
 

--- a/docs/effects/all-effects/set_item_data.md
+++ b/docs/effects/all-effects/set_item_data.md
@@ -1,5 +1,6 @@
 # `set_item_data`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Set item data
 

--- a/docs/effects/all-effects/set_item_points.md
+++ b/docs/effects/all-effects/set_item_points.md
@@ -1,5 +1,6 @@
 # `set_item_points`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Set item points (check the points wiki page if you don't know what these are)
 

--- a/docs/effects/all-effects/set_lands_balance.md
+++ b/docs/effects/all-effects/set_lands_balance.md
@@ -1,6 +1,7 @@
 # `set_lands_balance`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Set the Land bank's balance
 

--- a/docs/effects/all-effects/set_points.md
+++ b/docs/effects/all-effects/set_points.md
@@ -1,5 +1,6 @@
 # `set_points`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Set points (check the points wiki page if you don't know what these are)
 

--- a/docs/effects/all-effects/set_saturation.md
+++ b/docs/effects/all-effects/set_saturation.md
@@ -1,5 +1,6 @@
 # `set_saturation`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Sets the player's saturation
 

--- a/docs/effects/all-effects/set_velocity.md
+++ b/docs/effects/all-effects/set_velocity.md
@@ -1,5 +1,6 @@
 # `set_velocity`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Sets your velocity
 

--- a/docs/effects/all-effects/set_victim_velocity.md
+++ b/docs/effects/all-effects/set_victim_velocity.md
@@ -1,5 +1,6 @@
 # `set_victim_velocity`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Sets the victim's velocity
 

--- a/docs/effects/all-effects/shoot.md
+++ b/docs/effects/all-effects/shoot.md
@@ -1,5 +1,6 @@
 # `shoot`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Shoots a [projectile](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/Projectile.html)
 

--- a/docs/effects/all-effects/shoot_arrow.md
+++ b/docs/effects/all-effects/shoot_arrow.md
@@ -1,5 +1,6 @@
 # `shoot_arrow`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Shoots an arrow
 

--- a/docs/effects/all-effects/shuffle_hotbar.md
+++ b/docs/effects/all-effects/shuffle_hotbar.md
@@ -1,5 +1,6 @@
 # `shuffle_hotbar`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Shuffle your victim's hotbar
 

--- a/docs/effects/all-effects/skill_xp_multiplier.md
+++ b/docs/effects/all-effects/skill_xp_multiplier.md
@@ -1,5 +1,6 @@
 # `skill_xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies skill xp gain
 

--- a/docs/effects/all-effects/smite.md
+++ b/docs/effects/all-effects/smite.md
@@ -1,5 +1,6 @@
 # `smite`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Strikes lightning on a victim
 

--- a/docs/effects/all-effects/sneaking_speed_multiplier.md
+++ b/docs/effects/all-effects/sneaking_speed_multiplier.md
@@ -1,5 +1,6 @@
 # `sneaking_speed_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies sneaking speed
 

--- a/docs/effects/all-effects/spawn_entity.md
+++ b/docs/effects/all-effects/spawn_entity.md
@@ -1,5 +1,6 @@
 # `spawn_entity`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Spawns an [entity](https://plugins.auxilor.io/all-plugins/the-entity-lookup-system)
 

--- a/docs/effects/all-effects/spawn_mobs.md
+++ b/docs/effects/all-effects/spawn_mobs.md
@@ -1,5 +1,6 @@
 # `spawn_mobs`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Spawns [mobs](https://plugins.auxilor.io/all-plugins/the-entity-lookup-system) to help you
 

--- a/docs/effects/all-effects/spawn_particle.md
+++ b/docs/effects/all-effects/spawn_particle.md
@@ -1,5 +1,6 @@
 # `spawn_particle`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Spawns a [particle](https://plugins.auxilor.io/all-plugins/the-particle-lookup-system)
 

--- a/docs/effects/all-effects/spawn_potion_cloud.md
+++ b/docs/effects/all-effects/spawn_potion_cloud.md
@@ -1,5 +1,6 @@
 # `spawn_potion_cloud`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Spawns a [potion](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionEffectType.html) cloud
 

--- a/docs/effects/all-effects/start_quest.md
+++ b/docs/effects/all-effects/start_quest.md
@@ -1,6 +1,7 @@
 # `start_quest`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Starts a quest for the player
 

--- a/docs/effects/all-effects/strike_lightning.md
+++ b/docs/effects/all-effects/strike_lightning.md
@@ -1,5 +1,6 @@
 # `strike_lightning`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Strikes lightning at a point
 

--- a/docs/effects/all-effects/strip_ai.md
+++ b/docs/effects/all-effects/strip_ai.md
@@ -1,5 +1,6 @@
 # `strip_ai`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Strips a mob's AI temporarily
 

--- a/docs/effects/all-effects/swarm.md
+++ b/docs/effects/all-effects/swarm.md
@@ -1,6 +1,7 @@
 # `swarm`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Makes nearby monsters in a certain radius attack the victim
 

--- a/docs/effects/all-effects/take_money.md
+++ b/docs/effects/all-effects/take_money.md
@@ -1,5 +1,6 @@
 # `take_money`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Takes money from the player
 

--- a/docs/effects/all-effects/target_player.md
+++ b/docs/effects/all-effects/target_player.md
@@ -1,6 +1,7 @@
 # `target_player`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Makes the victim target the player (requires the victim to be a monster)
 

--- a/docs/effects/all-effects/telekinesis.md
+++ b/docs/effects/all-effects/telekinesis.md
@@ -1,5 +1,6 @@
 # `telekinesis`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Teleports all drops to the player's inventory
 

--- a/docs/effects/all-effects/teleport.md
+++ b/docs/effects/all-effects/teleport.md
@@ -1,5 +1,6 @@
 # `teleport`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Teleports to a location
 

--- a/docs/effects/all-effects/teleport_to.md
+++ b/docs/effects/all-effects/teleport_to.md
@@ -1,5 +1,6 @@
 # `teleport_to`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Teleport a player to a specific location
 

--- a/docs/effects/all-effects/teleport_to_ground.md
+++ b/docs/effects/all-effects/teleport_to_ground.md
@@ -1,5 +1,6 @@
 # `teleport_to_ground`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Teleports to the ground
 

--- a/docs/effects/all-effects/total_damage_multiplier.md
+++ b/docs/effects/all-effects/total_damage_multiplier.md
@@ -1,5 +1,6 @@
 # `total_damage_multiplier`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Multiplies all incoming or outgoing damage from any damage trigger
 

--- a/docs/effects/all-effects/traceback.md
+++ b/docs/effects/all-effects/traceback.md
@@ -1,5 +1,6 @@
 # `traceback`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Go back to a previous position
 

--- a/docs/effects/all-effects/transmission.md
+++ b/docs/effects/all-effects/transmission.md
@@ -1,5 +1,6 @@
 # `transmission`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Teleport a player forward in the direction they're facing (Like AotE)
 

--- a/docs/effects/all-effects/trigger_custom.md
+++ b/docs/effects/all-effects/trigger_custom.md
@@ -1,5 +1,6 @@
 # `trigger_custom`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Call a custom trigger
 

--- a/docs/effects/all-effects/underwater_mining_speed_multiplier.md
+++ b/docs/effects/all-effects/underwater_mining_speed_multiplier.md
@@ -1,5 +1,6 @@
 # `underwater_mining_speed_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies underwater mining speed
 

--- a/docs/effects/all-effects/update_boss_bar.md
+++ b/docs/effects/all-effects/update_boss_bar.md
@@ -1,5 +1,6 @@
 # `update_boss_bar`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Updates a boss bar
 

--- a/docs/effects/all-effects/victim_speed_multiplier.md
+++ b/docs/effects/all-effects/victim_speed_multiplier.md
@@ -1,5 +1,6 @@
 # `victim_speed_multiplier`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Temporarily multiplies victim movement speed
 

--- a/docs/effects/all-effects/water_movement_efficiency_multiplier.md
+++ b/docs/effects/all-effects/water_movement_efficiency_multiplier.md
@@ -1,5 +1,6 @@
 # `water_movement_efficiency_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies water movement efficiency
 

--- a/docs/effects/all-effects/xp_multiplier.md
+++ b/docs/effects/all-effects/xp_multiplier.md
@@ -1,5 +1,6 @@
 # `xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies incoming xp gain
 

--- a/docs/effects/external-integrations/auraskills/effects/add_stat.md
+++ b/docs/effects/external-integrations/auraskills/effects/add_stat.md
@@ -1,5 +1,6 @@
 # `add_stat`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Adds a value to a specific stat
 

--- a/docs/effects/external-integrations/auraskills/effects/skill_xp_multiplier.md
+++ b/docs/effects/external-integrations/auraskills/effects/skill_xp_multiplier.md
@@ -1,5 +1,6 @@
 # `skill_xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies skill xp gain
 

--- a/docs/effects/external-integrations/flaremobcoins/effects/mob_coins_multiplier.md
+++ b/docs/effects/external-integrations/flaremobcoins/effects/mob_coins_multiplier.md
@@ -1,5 +1,6 @@
 # `mob_coins_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies mob coin drops
 

--- a/docs/effects/external-integrations/jobs-reborn/effects/jobs_money_multiplier.md
+++ b/docs/effects/external-integrations/jobs-reborn/effects/jobs_money_multiplier.md
@@ -1,5 +1,6 @@
 # `jobs_money_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies money gain from jobs
 

--- a/docs/effects/external-integrations/jobs-reborn/effects/jobs_xp_multiplier.md
+++ b/docs/effects/external-integrations/jobs-reborn/effects/jobs_xp_multiplier.md
@@ -1,5 +1,6 @@
 # `jobs_xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies xp gain from jobs
 

--- a/docs/effects/external-integrations/lands/effects/give_lands_balance.md
+++ b/docs/effects/external-integrations/lands/effects/give_lands_balance.md
@@ -1,6 +1,7 @@
 # `give_lands_balance`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Give money to a Land's bank balance
 

--- a/docs/effects/external-integrations/lands/effects/set_lands_balance.md
+++ b/docs/effects/external-integrations/lands/effects/set_lands_balance.md
@@ -1,6 +1,7 @@
 # `set_lands_balance`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Set the Land bank's balance
 

--- a/docs/effects/external-integrations/mcmmo/effects/give_mcmmo_xp.md
+++ b/docs/effects/external-integrations/mcmmo/effects/give_mcmmo_xp.md
@@ -1,5 +1,6 @@
 # `give_mcmmo_xp`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives experience points for a certain skill
 

--- a/docs/effects/external-integrations/mcmmo/effects/mcmmo_xp_multiplier.md
+++ b/docs/effects/external-integrations/mcmmo/effects/mcmmo_xp_multiplier.md
@@ -1,5 +1,6 @@
 # `mcmmo_xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies mcMMO skill xp gain
 

--- a/docs/effects/external-integrations/modelengine/effects/play_animation.md
+++ b/docs/effects/external-integrations/modelengine/effects/play_animation.md
@@ -1,5 +1,6 @@
 # `play_animation`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Plays a Model Engine animation (The entity must have a custom model active)
 

--- a/docs/effects/external-integrations/paper/effects/drop_pickup_item.md
+++ b/docs/effects/external-integrations/paper/effects/drop_pickup_item.md
@@ -1,6 +1,7 @@
 # `drop_pickup_item`
 
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Drops an item that runs a chain on pickup
 

--- a/docs/effects/external-integrations/paper/effects/elytra_boost_save_chance.md
+++ b/docs/effects/external-integrations/paper/effects/elytra_boost_save_chance.md
@@ -1,5 +1,6 @@
 # `elytra_boost_save_chance`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Prevents consuming fireworks when boosting with an elytra
 

--- a/docs/effects/external-integrations/paper/effects/send_minimessage.md
+++ b/docs/effects/external-integrations/paper/effects/send_minimessage.md
@@ -1,5 +1,6 @@
 # `send_minimessage`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Sends the player a minimessage message, supports clickable components, etc.
 

--- a/docs/effects/external-integrations/ultimatemobcoins/effects/mob_coins_chance_multiplier.md
+++ b/docs/effects/external-integrations/ultimatemobcoins/effects/mob_coins_chance_multiplier.md
@@ -1,5 +1,6 @@
 # `mob_coins_chance_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies the chance of mobcoins being dropped
 

--- a/docs/effects/external-integrations/ultimatemobcoins/effects/mob_coins_drop_multiplier.md
+++ b/docs/effects/external-integrations/ultimatemobcoins/effects/mob_coins_drop_multiplier.md
@@ -1,5 +1,6 @@
 # `mob_coins_drop_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies the mobcoins dropped
 

--- a/docs/effects/external-integrations/vault/effects/give_permission.md
+++ b/docs/effects/external-integrations/vault/effects/give_permission.md
@@ -1,5 +1,6 @@
 # `give_permission`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Gives a permission while active
 

--- a/docs/effects/external-integrations/xbattlepass/effects/battlepass_task_xp_multiplier.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/battlepass_task_xp_multiplier.md
@@ -1,5 +1,6 @@
 # `battlepass_task_xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies incoming battlepass task xp gain
 

--- a/docs/effects/external-integrations/xbattlepass/effects/battlepass_xp_multiplier.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/battlepass_xp_multiplier.md
@@ -1,5 +1,6 @@
 # `battlepass_xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+:::
 
 Multiplies incoming battlepass xp gain
 

--- a/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_task_xp.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_task_xp.md
@@ -1,5 +1,6 @@
 # `give_battlepass_task_xp`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Gives experience points for a task in a quest, excluding multipliers.
 

--- a/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_tier.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_tier.md
@@ -1,5 +1,6 @@
 # `give_battlepass_tier`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Give battlepass tiers to the player.
 

--- a/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_xp.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_xp.md
@@ -1,5 +1,6 @@
 # `give_battlepass_xp`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Give battlepass experience points
 

--- a/docs/effects/external-integrations/xbattlepass/effects/set_battlepass_tier.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/set_battlepass_tier.md
@@ -1,5 +1,6 @@
 # `set_battlepass_tier`
-#### Triggered Effect
+:::dangerTriggered Effect
+:::
 
 Set the player's battlepass tier
 


### PR DESCRIPTION
Replaces '#### Triggered Effect' and '#### Permanent Effect' headers with callout blocks using :::danger and :::info, respectively, across all effect documentation files. This improves consistency and visual clarity in the documentation.