### PR TITLE
Standardize plugin requirement and effect type formatting

### DIFF
--- a/docs/all-plugins/custom-entity-ai/all-entity-goals/ecomobs_random_teleport.md
+++ b/docs/all-plugins/custom-entity-ai/all-entity-goals/ecomobs_random_teleport.md
@@ -2,7 +2,9 @@
 
 Allows a mob to teleport around randomly
 
-**Requires EcoMobs**
+:::warningRequires:
+EcoMobs
+:::
 
 # Example Config
 ```yaml

--- a/docs/boosters/boosters-effects/conditions/is_booster_active.md
+++ b/docs/boosters/boosters-effects/conditions/is_booster_active.md
@@ -2,7 +2,9 @@
 
 Requires a certain booster to be active on the server
 
-**Requires Boosters**
+:::warningRequires:
+Boosters
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoarmor/ecoarmor-effects/conditions/is_wearing_set.md
+++ b/docs/ecoarmor/ecoarmor-effects/conditions/is_wearing_set.md
@@ -2,7 +2,9 @@
 
 Requires a player to be wearing a certain EcoArmor set
 
-**Requires EcoArmor**
+:::warningRequires:
+EcoArmor
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoitems/ecoitems-effects/conditions/has_ecoitem.md
+++ b/docs/ecoitems/ecoitems-effects/conditions/has_ecoitem.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain EcoItem active
 
-**Requires EcoItems**
+:::warningRequires:
+EcoItems
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecojobs/ecojobs-effects/conditions/has_active_job.md
+++ b/docs/ecojobs/ecojobs-effects/conditions/has_active_job.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a job active
 
-**Requires EcoJobs**
+:::warningRequires:
+EcoJobs
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecojobs/ecojobs-effects/conditions/has_job_level.md
+++ b/docs/ecojobs/ecojobs-effects/conditions/has_job_level.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain job level
 
-**Requires EcoJobs**
+:::warningRequires:
+EcoJobs
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecojobs/ecojobs-effects/effects/give_job_xp.md
+++ b/docs/ecojobs/ecojobs-effects/effects/give_job_xp.md
@@ -1,9 +1,13 @@
 # `give_job_xp`
-#### Triggered Effect
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
 
 Gives experience points for a certain job
 
-**Requires EcoJobs**
+:::warningRequires:
+EcoJobs
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecojobs/ecojobs-effects/effects/job_xp_multiplier.md
+++ b/docs/ecojobs/ecojobs-effects/effects/job_xp_multiplier.md
@@ -1,9 +1,13 @@
 # `job_xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+This effect is permanent and does not require a trigger.
+:::
 
 Multiplies job xp gain
 
-**Requires EcoJobs**
+:::warningRequires:
+EcoJobs
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecojobs/ecojobs-effects/filters/job.md
+++ b/docs/ecojobs/ecojobs-effects/filters/job.md
@@ -2,7 +2,9 @@
 
 Require a certain job
 
-**Requires EcoJobs**
+:::warningRequires:
+EcoJobs
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecopets/ecopets-effects/conditions/has_active_pet.md
+++ b/docs/ecopets/ecopets-effects/conditions/has_active_pet.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a pet active
 
-**Requires EcoPets**
+:::warningRequires:
+EcoPets
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecopets/ecopets-effects/conditions/has_pet.md
+++ b/docs/ecopets/ecopets-effects/conditions/has_pet.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain pet
 
-**Requires EcoPets**
+:::warningRequires:
+EcoPets
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecopets/ecopets-effects/conditions/has_pet_level.md
+++ b/docs/ecopets/ecopets-effects/conditions/has_pet_level.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain pet level
 
-**Requires EcoPets**
+:::warningRequires:
+EcoPets
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecopets/ecopets-effects/effects/give_pet_xp.md
+++ b/docs/ecopets/ecopets-effects/effects/give_pet_xp.md
@@ -1,9 +1,13 @@
 # `give_pet_xp`
-#### Triggered Effect
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
 
 Gives experience points for a certain pet
 
-**Requires EcoPets**
+:::warningRequires:
+EcoPets
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecopets/ecopets-effects/effects/pet_xp_multiplier.md
+++ b/docs/ecopets/ecopets-effects/effects/pet_xp_multiplier.md
@@ -1,9 +1,13 @@
 # `pet_xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+This effect is permanent and does not require a trigger.
+:::
 
 Multiplies pet xp gain
 
-**Requires EcoPets**
+:::warningRequires:
+EcoPets
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecopets/ecopets-effects/filters/pet.md
+++ b/docs/ecopets/ecopets-effects/filters/pet.md
@@ -2,7 +2,10 @@
 
 Require a certain pet
 
-**Requires EcoPets**
+:::warningRequires:
+EcoJobs
+:::
+
 
 # Example Config
 ```yaml

--- a/docs/ecoquests/ecoquests-effects/conditions/has_completed_quest.md
+++ b/docs/ecoquests/ecoquests-effects/conditions/has_completed_quest.md
@@ -2,7 +2,9 @@
 
 Requires a player to have completed a quest
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoquests/ecoquests-effects/conditions/has_completed_task.md
+++ b/docs/ecoquests/ecoquests-effects/conditions/has_completed_task.md
@@ -2,7 +2,9 @@
 
 Requires a player to have completed task for a quest
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoquests/ecoquests-effects/conditions/has_quest_active.md
+++ b/docs/ecoquests/ecoquests-effects/conditions/has_quest_active.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a quest active
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoquests/ecoquests-effects/effects/gain_task_xp.md
+++ b/docs/ecoquests/ecoquests-effects/effects/gain_task_xp.md
@@ -1,10 +1,13 @@
 # `gain_task_xp`
-
-#### Triggered Effect
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
 
 Gains experience points for a task in a quest, including multipliers.
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Example Config
 

--- a/docs/ecoquests/ecoquests-effects/effects/give_task_xp.md
+++ b/docs/ecoquests/ecoquests-effects/effects/give_task_xp.md
@@ -1,10 +1,13 @@
 # `give_task_xp`
-
-#### Triggered Effect
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
 
 Gives experience points for a task in a quest, excluding multipliers.
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Example Config
 

--- a/docs/ecoquests/ecoquests-effects/effects/quest_xp_multiplier.md
+++ b/docs/ecoquests/ecoquests-effects/effects/quest_xp_multiplier.md
@@ -1,9 +1,13 @@
 # `quest_xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+This effect is permanent and does not require a trigger.
+:::
 
 Multiplies quest xp gain
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoquests/ecoquests-effects/effects/start_quest.md
+++ b/docs/ecoquests/ecoquests-effects/effects/start_quest.md
@@ -1,10 +1,13 @@
 # `start_quest`
-
-#### Triggered Effect
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
 
 Starts a quest for the player
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Example Config
 

--- a/docs/ecoquests/ecoquests-effects/filters/quest.md
+++ b/docs/ecoquests/ecoquests-effects/filters/quest.md
@@ -2,7 +2,9 @@
 
 Require a certain quest
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoquests/ecoquests-effects/filters/task.md
+++ b/docs/ecoquests/ecoquests-effects/filters/task.md
@@ -2,7 +2,9 @@
 
 Require a certain task
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoscrolls/ecoscrolls-effects/conditions/has_scroll.md
+++ b/docs/ecoscrolls/ecoscrolls-effects/conditions/has_scroll.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain scroll active
 
-**Requires EcoScrolls**
+:::warningRequires:
+EcoScrolls
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoscrolls/ecoscrolls-effects/effects/inscribe_item.md
+++ b/docs/ecoscrolls/ecoscrolls-effects/effects/inscribe_item.md
@@ -1,10 +1,13 @@
 # `inscribe_item`
-
-#### Triggered Effect
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
 
 Inscribes an item with a scroll
 
-**Requires EcoScrolls**
+:::warningRequires:
+EcoScrolls
+:::
 
 # Example Config
 

--- a/docs/ecoscrolls/ecoscrolls-effects/filters/scroll.md
+++ b/docs/ecoscrolls/ecoscrolls-effects/filters/scroll.md
@@ -2,7 +2,9 @@
 
 Require a certain scroll
 
-**Requires EcoScrolls**
+:::warningRequires:
+EcoScrolls
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoshop/ecoshop-effects/filters/shop_item.md
+++ b/docs/ecoshop/ecoshop-effects/filters/shop_item.md
@@ -2,7 +2,9 @@
 
 Require a certain shop item
 
-**Requires EcoShop**
+:::warningRequires:
+EcoShop
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/conditions/above_magic.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/above_magic.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain amount of magic
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/conditions/below_magic.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/below_magic.md
@@ -2,7 +2,9 @@
 
 Requires a player to have less than a certain amount of magic
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/conditions/has_skill_level.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/has_skill_level.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain skill level
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/conditions/stat_above.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/stat_above.md
@@ -2,7 +2,9 @@
 
 Requires a player to have at least a certain stat level
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 

--- a/docs/ecoskills/ecoskills-effects/conditions/stat_below.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/stat_below.md
@@ -2,7 +2,9 @@
 
 Requires a player to have less than a certain stat level
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 

--- a/docs/ecoskills/ecoskills-effects/conditions/stat_equals.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/stat_equals.md
@@ -2,7 +2,9 @@
 
 Requires a player to have exactly a certain stat level
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 

--- a/docs/ecoskills/ecoskills-effects/effects/add_stat.md
+++ b/docs/ecoskills/ecoskills-effects/effects/add_stat.md
@@ -1,5 +1,7 @@
 # `add_stat`
-#### Permanent Effect
+:::infoPermanent Effect
+This effect is permanent and does not require a trigger.
+:::
 
 Adds a value to a specific stat
 

--- a/docs/ecoskills/ecoskills-effects/effects/add_stat_temporarily.md
+++ b/docs/ecoskills/ecoskills-effects/effects/add_stat_temporarily.md
@@ -1,9 +1,13 @@
 # `add_stat_temporarily`
-#### Triggered Effect
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
 
 Adds a value to a specific stat
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/effects/give_magic.md
+++ b/docs/ecoskills/ecoskills-effects/effects/give_magic.md
@@ -1,9 +1,13 @@
 # `give_magic`
-#### Triggered Effect
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
 
 Add / subtract magic
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/effects/give_skill_xp.md
+++ b/docs/ecoskills/ecoskills-effects/effects/give_skill_xp.md
@@ -1,9 +1,13 @@
 # `give_skill_xp`
-#### Triggered Effect
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
 
 Gives experience points for a certain skill
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/effects/give_skill_xp_naturally.md
+++ b/docs/ecoskills/ecoskills-effects/effects/give_skill_xp_naturally.md
@@ -1,11 +1,15 @@
 # `give_skill_xp_naturally`
-#### Triggered Effect
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
 
 Gives naturally-gained experience points for a certain skill
 
 This will send a message to a player and will include multipliers.
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/effects/magic_regen_multiplier.md
+++ b/docs/ecoskills/ecoskills-effects/effects/magic_regen_multiplier.md
@@ -1,9 +1,13 @@
 # `magic_regen_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+This effect is permanent and does not require a trigger.
+:::
 
 Multiplies magic regeneration
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/effects/make_skill_crit.md
+++ b/docs/ecoskills/ecoskills-effects/effects/make_skill_crit.md
@@ -1,9 +1,13 @@
 # `make_skill_crit`
-#### Triggered Effect
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
 
 Deal a crit hit
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/effects/multiply_all_stats.md
+++ b/docs/ecoskills/ecoskills-effects/effects/multiply_all_stats.md
@@ -1,9 +1,13 @@
 # `multiply_all_stats`
-#### Permanent Effect
+:::infoPermanent Effect
+This effect is permanent and does not require a trigger.
+:::
 
 Multiplies all stats by a specific value
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/effects/multiply_magic.md
+++ b/docs/ecoskills/ecoskills-effects/effects/multiply_magic.md
@@ -1,9 +1,13 @@
 # `multiply_magic`
-#### Triggered Effect
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
 
 Multiply magic
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/effects/multiply_stat.md
+++ b/docs/ecoskills/ecoskills-effects/effects/multiply_stat.md
@@ -1,9 +1,13 @@
 # `multiply_stat`
-#### Permanent Effect
+:::infoPermanent Effect
+This effect is permanent and does not require a trigger.
+:::
 
 Multiplies a stat by a specific value
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/effects/multiply_stat_temporarily.md
+++ b/docs/ecoskills/ecoskills-effects/effects/multiply_stat_temporarily.md
@@ -1,9 +1,13 @@
 # `multiply_stat_temporarily`
-#### Triggered Effect
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
 
 Multiplies a stat by a specific value
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/effects/skill_xp_multiplier.md
+++ b/docs/ecoskills/ecoskills-effects/effects/skill_xp_multiplier.md
@@ -1,5 +1,7 @@
 # `skill_xp_multiplier`
-#### Permanent Effect
+:::infoPermanent Effect
+This effect is permanent and does not require a trigger.
+:::
 
 Multiplies skill xp gain
 

--- a/docs/ecoskills/ecoskills-effects/filters/magic_type.md
+++ b/docs/ecoskills/ecoskills-effects/filters/magic_type.md
@@ -2,7 +2,9 @@
 
 Require a certain magic type
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/filters/skill.md
+++ b/docs/ecoskills/ecoskills-effects/filters/skill.md
@@ -2,7 +2,9 @@
 
 Require a certain skill
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/all-conditions/above_balance.md
+++ b/docs/effects/all-conditions/above_balance.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain amount of money
 
-**Requires Vault**
+:::warningRequires:
+Vault
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/above_magic.md
+++ b/docs/effects/all-conditions/above_magic.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain amount of magic
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/below_balance.md
+++ b/docs/effects/all-conditions/below_balance.md
@@ -2,7 +2,9 @@
 
 Requires a player to have below a certain amount of money
 
-**Requires Vault**
+:::warningRequires:
+Vault
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/below_magic.md
+++ b/docs/effects/all-conditions/below_magic.md
@@ -2,7 +2,9 @@
 
 Requires a player to have less than a certain amount of magic
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_active_job.md
+++ b/docs/effects/all-conditions/has_active_job.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a job active
 
-**Requires EcoJobs**
+:::warningRequires:
+EcoJobs
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_active_pet.md
+++ b/docs/effects/all-conditions/has_active_pet.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a pet active
 
-**Requires EcoPets**
+:::warningRequires:
+EcoPets
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_battlepass_tier.md
+++ b/docs/effects/all-conditions/has_battlepass_tier.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain battlepass tier
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Condition Syntax
 ```yaml
 - id: has_battlepass_tier

--- a/docs/effects/all-conditions/has_boss_bar_visible.md
+++ b/docs/effects/all-conditions/has_boss_bar_visible.md
@@ -2,7 +2,9 @@
 
 Requires a player to have the TAB boss bar shown to them
 
-**Requires TAB**
+:::warningRequires:
+TAB
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_completed_quest.md
+++ b/docs/effects/all-conditions/has_completed_quest.md
@@ -2,7 +2,9 @@
 
 Requires a player to have completed a quest
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_completed_task.md
+++ b/docs/effects/all-conditions/has_completed_task.md
@@ -2,7 +2,9 @@
 
 Requires a player to have completed task for a quest
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_ecoitem.md
+++ b/docs/effects/all-conditions/has_ecoitem.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain EcoItem active
 
-**Requires EcoItems**
+:::warningRequires:
+EcoItems
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_job_level.md
+++ b/docs/effects/all-conditions/has_job_level.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain job level
 
-**Requires EcoJobs**
+:::warningRequires:
+EcoJobs
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_lands_role.md
+++ b/docs/effects/all-conditions/has_lands_role.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain role in the Land
 
-**Requires Lands**
+:::warningRequires:
+Lands
+:::
 # Condition Syntax
 ```yaml
 - id: has_lands_role

--- a/docs/effects/all-conditions/has_mana.md
+++ b/docs/effects/all-conditions/has_mana.md
@@ -2,7 +2,9 @@
 
 Requires a player to have amount of mana
 
-**Requires AuraSkills**
+:::warningRequires:
+AuraSkills
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_mcmmo_level.md
+++ b/docs/effects/all-conditions/has_mcmmo_level.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain McMMO skill level
 
-**Requires McMMO**
+:::warningRequires:
+McMMO
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_pet.md
+++ b/docs/effects/all-conditions/has_pet.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain pet
 
-**Requires EcoPets**
+:::warningRequires:
+EcoPets
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_pet_level.md
+++ b/docs/effects/all-conditions/has_pet_level.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain pet level
 
-**Requires EcoPets**
+:::warningRequires:
+EcoPets
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_premium_battlepass.md
+++ b/docs/effects/all-conditions/has_premium_battlepass.md
@@ -2,7 +2,9 @@
 
 Requires a player to have the premium battlepass
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Condition Syntax
 ```yaml
 - id: has_premium_battlepass

--- a/docs/effects/all-conditions/has_quest_active.md
+++ b/docs/effects/all-conditions/has_quest_active.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a quest active
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_reforge.md
+++ b/docs/effects/all-conditions/has_reforge.md
@@ -2,7 +2,10 @@
 
 Requires a player to have a certain reforge active
 
-**Requires Reforges**
+
+:::warningRequires:
+Reforges
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_scoreboard_visible.md
+++ b/docs/effects/all-conditions/has_scoreboard_visible.md
@@ -2,7 +2,9 @@
 
 Requires a player to have the TAB scoreboard shown to them
 
-**Requires TAB**
+:::warningRequires:
+TAB
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_scroll.md
+++ b/docs/effects/all-conditions/has_scroll.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain scroll active
 
-**Requires EcoScrolls**
+:::warningRequires:
+EcoScrolls
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_skill_level.md
+++ b/docs/effects/all-conditions/has_skill_level.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain skill level
 
-**Requires EcoSkills or AuraSkills**
+:::warningRequires:
+EcoSkills / AuraSkills
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_talisman.md
+++ b/docs/effects/all-conditions/has_talisman.md
@@ -2,7 +2,10 @@
 
 Requires a player to have a certain talisman active
 
-**Requires Talismans**
+
+:::warningRequires:
+Talismans
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/has_town_role.md
+++ b/docs/effects/all-conditions/has_town_role.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain role in a town
 
-**Requires HuskTowns**
+:::warningRequires:
+HuskTowns
+:::
 # Condition Syntax
 ```yaml
 - id: has_town_role

--- a/docs/effects/all-conditions/in_bubble.md
+++ b/docs/effects/all-conditions/in_bubble.md
@@ -2,7 +2,9 @@
 
 Requires a player to be in a bubble column
 
-**Requires Paper**
+:::warningRequires:
+Paper
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/in_lava.md
+++ b/docs/effects/all-conditions/in_lava.md
@@ -2,7 +2,9 @@
 
 Requires a player to be in lava
 
-**Requires Paper**
+:::warningRequires:
+Paper
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/in_own_claim.md
+++ b/docs/effects/all-conditions/in_own_claim.md
@@ -2,7 +2,9 @@
 
 Requires the player to be in their own claim
 
-**Requires HuskClaims, HuskTowns or Lands**
+:::warningRequires:
+HuskClaims || HuskTowns || Lands
+:::
 # Condition Syntax
 ```yaml
 - id: in_own_claim

--- a/docs/effects/all-conditions/in_rain.md
+++ b/docs/effects/all-conditions/in_rain.md
@@ -2,7 +2,9 @@
 
 Requires a player to be in rain
 
-**Requires Paper**
+:::warningRequires:
+Paper
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/in_region.md
+++ b/docs/effects/all-conditions/in_region.md
@@ -2,7 +2,10 @@
 
 Requires a player to be in a certain region
 
-**Requires WorldGuard**
+
+:::warningRequires:
+WorldGuard
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/in_trusted_claim.md
+++ b/docs/effects/all-conditions/in_trusted_claim.md
@@ -2,7 +2,9 @@
 
 Requires the player to be in a claim they're trusted in
 
-**Requires Lands**
+:::warningRequires:
+Lands
+:::
 # Condition Syntax
 ```yaml
 - id: in_trusted_claim

--- a/docs/effects/all-conditions/is_booster_active.md
+++ b/docs/effects/all-conditions/is_booster_active.md
@@ -2,7 +2,9 @@
 
 Requires a certain booster to be active on the server
 
-**Requires Boosters**
+:::warningRequires:
+Boosters
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/is_season.md
+++ b/docs/effects/all-conditions/is_season.md
@@ -2,7 +2,9 @@
 
 Requires it to be a certain season
 
-**Requires CustomCrops**
+:::warningRequires:
+CustomCrops
+:::
 # Condition Syntax
 ```yaml
 - id: is_season

--- a/docs/effects/all-conditions/is_wearing_set.md
+++ b/docs/effects/all-conditions/is_wearing_set.md
@@ -2,7 +2,9 @@
 
 Requires a player to be wearing a certain EcoArmor set
 
-**Requires EcoArmor**
+:::warningRequires:
+EcoArmor
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/lands_balance_above.md
+++ b/docs/effects/all-conditions/lands_balance_above.md
@@ -2,7 +2,9 @@
 
 Requires the Land's bank balance to be above a value
 
-**Requires Lands**
+:::warningRequires:
+Lands
+:::
 # Condition Syntax
 ```yaml
 - id: lands_balance_above

--- a/docs/effects/all-conditions/lands_balance_below.md
+++ b/docs/effects/all-conditions/lands_balance_below.md
@@ -2,7 +2,9 @@
 
 Requires the Land's bank balance to be below a value
 
-**Requires Lands**
+:::warningRequires:
+Lands
+:::
 # Condition Syntax
 ```yaml
 - id: lands_balance_below

--- a/docs/effects/all-conditions/lands_balance_equal.md
+++ b/docs/effects/all-conditions/lands_balance_equal.md
@@ -2,7 +2,9 @@
 
 Requires the Land's bank balance to be equal to a value
 
-**Requires Lands**
+:::warningRequires:
+Lands
+:::
 # Condition Syntax
 ```yaml
 - id: lands_balance_equal

--- a/docs/effects/all-conditions/mcmmo_ability_on_cooldown.md
+++ b/docs/effects/all-conditions/mcmmo_ability_on_cooldown.md
@@ -2,7 +2,9 @@
 
 Requires an McMMO ability to be on cooldown
 
-**Requires McMMO**
+:::warningRequires:
+McMMO
+:::
 
 # Condition Syntax
 ```yaml

--- a/docs/effects/all-conditions/stat_above.md
+++ b/docs/effects/all-conditions/stat_above.md
@@ -2,7 +2,9 @@
 
 Requires a player to have at least a certain stat level
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Condition Syntax
 

--- a/docs/effects/all-conditions/stat_below.md
+++ b/docs/effects/all-conditions/stat_below.md
@@ -2,7 +2,9 @@
 
 Requires a player to have less than a certain stat level
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Condition Syntax
 

--- a/docs/effects/all-conditions/stat_equals.md
+++ b/docs/effects/all-conditions/stat_equals.md
@@ -2,7 +2,9 @@
 
 Requires a player to have exactly a certain stat level
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Condition Syntax
 

--- a/docs/effects/all-effects/add_damage.md
+++ b/docs/effects/all-effects/add_damage.md
@@ -1,5 +1,6 @@
 # `add_damage`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Adds incoming or outgoing damage from any damage trigger

--- a/docs/effects/all-effects/add_durability.md
+++ b/docs/effects/all-effects/add_durability.md
@@ -1,10 +1,13 @@
 # `add_durability`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Increase the max durability of an item
 
-**Requires 1.21+**
+:::warningRequires:
+Server Version 1.21+
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/add_enchant.md
+++ b/docs/effects/all-effects/add_enchant.md
@@ -1,5 +1,6 @@
 # `add_enchant`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Adds an enchant to the item

--- a/docs/effects/all-effects/add_global_points.md
+++ b/docs/effects/all-effects/add_global_points.md
@@ -1,5 +1,6 @@
 # `add_global_points`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Add / subtract global points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)

--- a/docs/effects/all-effects/add_holder.md
+++ b/docs/effects/all-effects/add_holder.md
@@ -1,5 +1,6 @@
 # `add_holder`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives a custom holder temporarily for a given period of time

--- a/docs/effects/all-effects/add_holder_in_radius.md
+++ b/docs/effects/all-effects/add_holder_in_radius.md
@@ -1,5 +1,6 @@
 # `add_holder_in_radius`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives a custom holder temporarily for a given period of time

--- a/docs/effects/all-effects/add_holder_to_victim.md
+++ b/docs/effects/all-effects/add_holder_to_victim.md
@@ -1,5 +1,6 @@
 # `add_holder_to_victim`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives a custom holder temporarily to your victim (they must be a player) for a given period of time

--- a/docs/effects/all-effects/add_permanent_holder_in_radius.md
+++ b/docs/effects/all-effects/add_permanent_holder_in_radius.md
@@ -1,5 +1,6 @@
 # `add_permanent_holder_in_radius`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Gives a custom holder to people within a certain radius of you.

--- a/docs/effects/all-effects/add_points.md
+++ b/docs/effects/all-effects/add_points.md
@@ -1,5 +1,6 @@
 # `add_points`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Add / subtract points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)

--- a/docs/effects/all-effects/add_stat.md
+++ b/docs/effects/all-effects/add_stat.md
@@ -1,10 +1,13 @@
 # `add_stat`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Adds a value to a specific stat
 
-**Requires EcoSkills / AuraSkills**
+:::warningRequires:
+EcoSkills / AuraSkills
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/add_stat_temporarily.md
+++ b/docs/effects/all-effects/add_stat_temporarily.md
@@ -1,10 +1,13 @@
 # `add_stat_temporarily`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Adds a value to a specific stat
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/age_crop.md
+++ b/docs/effects/all-effects/age_crop.md
@@ -1,5 +1,6 @@
 # `age_crop`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 If the block is a crop, age it by a certain amount

--- a/docs/effects/all-effects/all_players.md
+++ b/docs/effects/all-effects/all_players.md
@@ -1,5 +1,6 @@
 # `all_players`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Runs effects for all players on the server

--- a/docs/effects/all-effects/animation.md
+++ b/docs/effects/all-effects/animation.md
@@ -1,6 +1,6 @@
 # `animation`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Plays an animation

--- a/docs/effects/all-effects/aoe.md
+++ b/docs/effects/all-effects/aoe.md
@@ -1,6 +1,6 @@
 # `aoe`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Runs effects for all entities within an area of effect (aoe)

--- a/docs/effects/all-effects/aoe_blocks.md
+++ b/docs/effects/all-effects/aoe_blocks.md
@@ -1,6 +1,6 @@
 # `aoe_blocks`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Runs effects for all blocks within an area of effect

--- a/docs/effects/all-effects/armor.md
+++ b/docs/effects/all-effects/armor.md
@@ -1,5 +1,6 @@
 # `armor`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Gives armor points

--- a/docs/effects/all-effects/armor_toughness.md
+++ b/docs/effects/all-effects/armor_toughness.md
@@ -1,5 +1,6 @@
 # `armor_toughness`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Gives armor toughness

--- a/docs/effects/all-effects/arrow_ring.md
+++ b/docs/effects/all-effects/arrow_ring.md
@@ -1,5 +1,6 @@
 # `arrow_ring`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Spawns a ring of arrows around a location

--- a/docs/effects/all-effects/attack_speed_multiplier.md
+++ b/docs/effects/all-effects/attack_speed_multiplier.md
@@ -1,5 +1,6 @@
 # `attack_speed_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies attack speed

--- a/docs/effects/all-effects/autosmelt.md
+++ b/docs/effects/all-effects/autosmelt.md
@@ -1,5 +1,6 @@
 # `autosmelt`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Autosmelts drops (requires a drop trigger)

--- a/docs/effects/all-effects/battlepass_task_xp_multiplier.md
+++ b/docs/effects/all-effects/battlepass_task_xp_multiplier.md
@@ -1,10 +1,13 @@
 # `battlepass_task_xp_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies incoming battlepass task xp gain
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Effect Syntax
 ```yaml
 - id: battlepass_task_xp_multiplier

--- a/docs/effects/all-effects/battlepass_xp_multiplier.md
+++ b/docs/effects/all-effects/battlepass_xp_multiplier.md
@@ -1,10 +1,13 @@
 # `battlepass_xp_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies incoming battlepass xp gain
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Effect Syntax
 ```yaml
 - id: battlepassxp_multiplier

--- a/docs/effects/all-effects/bleed.md
+++ b/docs/effects/all-effects/bleed.md
@@ -1,5 +1,6 @@
 # `bleed`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Makes your victim bleed, damaging them repeatedly

--- a/docs/effects/all-effects/block_commands.md
+++ b/docs/effects/all-effects/block_commands.md
@@ -1,5 +1,6 @@
 # `block_commands`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Prevents the execution of certain commands

--- a/docs/effects/all-effects/block_reach.md
+++ b/docs/effects/all-effects/block_reach.md
@@ -1,10 +1,13 @@
 # `block_reach`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Adds reach for interacting with blocks
 
-**Requires 1.21+**
+:::warningRequires:
+Server Version 1.21+
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/bonus_health.md
+++ b/docs/effects/all-effects/bonus_health.md
@@ -1,5 +1,6 @@
 # `bonus_health`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Gives extra health

--- a/docs/effects/all-effects/break_block.md
+++ b/docs/effects/all-effects/break_block.md
@@ -1,5 +1,6 @@
 # `break_block`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Breaks a block instantly

--- a/docs/effects/all-effects/brew_time_multiplier.md
+++ b/docs/effects/all-effects/brew_time_multiplier.md
@@ -1,5 +1,6 @@
 # `brew_time_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies the time taken to brew potions

--- a/docs/effects/all-effects/broadcast.md
+++ b/docs/effects/all-effects/broadcast.md
@@ -1,5 +1,6 @@
 # `broadcast`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Send a message to everyone online

--- a/docs/effects/all-effects/burning_time_multiplier.md
+++ b/docs/effects/all-effects/burning_time_multiplier.md
@@ -1,10 +1,13 @@
 # `burning_time_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies how long an entity is on fire after being ignited
 
-**Requires 1.21+**
+:::warningRequires:
+Server Version 1.21+
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/cancel_event.md
+++ b/docs/effects/all-effects/cancel_event.md
@@ -1,5 +1,6 @@
 # `cancel_event`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Cancel the event that fired the trigger

--- a/docs/effects/all-effects/clear_invulnerability.md
+++ b/docs/effects/all-effects/clear_invulnerability.md
@@ -1,6 +1,6 @@
 # `clear_invulnerability`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Removes the victim's invulnerability frame

--- a/docs/effects/all-effects/close_inventory.md
+++ b/docs/effects/all-effects/close_inventory.md
@@ -1,5 +1,6 @@
 # `close_inventory`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Closes the player's inventory

--- a/docs/effects/all-effects/consume_held_item.md
+++ b/docs/effects/all-effects/consume_held_item.md
@@ -1,5 +1,6 @@
 # `consume_held_item`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Consume items held in the player's main hand

--- a/docs/effects/all-effects/create_boss_bar.md
+++ b/docs/effects/all-effects/create_boss_bar.md
@@ -1,5 +1,6 @@
 # `create_boss_bar`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Creates a boss bar and shows it to the player

--- a/docs/effects/all-effects/create_explosion.md
+++ b/docs/effects/all-effects/create_explosion.md
@@ -1,5 +1,6 @@
 # `create_explosion`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Creates an explosion

--- a/docs/effects/all-effects/create_hologram.md
+++ b/docs/effects/all-effects/create_hologram.md
@@ -1,6 +1,6 @@
 # `create_hologram`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Creates a hologram temporarily (Requires a hologram plugin to be installed)

--- a/docs/effects/all-effects/crit_multiplier.md
+++ b/docs/effects/all-effects/crit_multiplier.md
@@ -1,5 +1,6 @@
 # `crit_multiplier`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Multiplies critical (falling) hit damage

--- a/docs/effects/all-effects/damage_armor.md
+++ b/docs/effects/all-effects/damage_armor.md
@@ -1,5 +1,6 @@
 # `damage_armor`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Damage a victim's armor

--- a/docs/effects/all-effects/damage_item.md
+++ b/docs/effects/all-effects/damage_item.md
@@ -1,5 +1,6 @@
 # `damage_item`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Damages the item

--- a/docs/effects/all-effects/damage_mainhand.md
+++ b/docs/effects/all-effects/damage_mainhand.md
@@ -1,5 +1,6 @@
 # `damage_mainhand`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Damage a victim's mainhand item

--- a/docs/effects/all-effects/damage_multiplier.md
+++ b/docs/effects/all-effects/damage_multiplier.md
@@ -1,5 +1,6 @@
 # `damage_multiplier`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Multiplies incoming or outgoing damage from any damage trigger

--- a/docs/effects/all-effects/damage_nearby_entities.md
+++ b/docs/effects/all-effects/damage_nearby_entities.md
@@ -1,5 +1,6 @@
 # `damage_nearby_entities`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Damage entities near a location

--- a/docs/effects/all-effects/damage_offhand.md
+++ b/docs/effects/all-effects/damage_offhand.md
@@ -1,5 +1,6 @@
 # `damage_offhand`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Damage a victim's offhand item

--- a/docs/effects/all-effects/damage_twice.md
+++ b/docs/effects/all-effects/damage_twice.md
@@ -1,5 +1,6 @@
 # `damage_twice`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Deals an extra hit to the victim

--- a/docs/effects/all-effects/damage_victim.md
+++ b/docs/effects/all-effects/damage_victim.md
@@ -1,5 +1,6 @@
 # `damage_victim`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Damage the victim

--- a/docs/effects/all-effects/dont_consume_lapis_chance.md
+++ b/docs/effects/all-effects/dont_consume_lapis_chance.md
@@ -1,5 +1,6 @@
 # `dont_consume_lapis_chance`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Prevents consuming lapis when enchanting items

--- a/docs/effects/all-effects/dont_consume_xp_chance.md
+++ b/docs/effects/all-effects/dont_consume_xp_chance.md
@@ -1,5 +1,6 @@
 # `dont_consume_xp_chance`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Prevents consuming xp when enchanting items

--- a/docs/effects/all-effects/drill.md
+++ b/docs/effects/all-effects/drill.md
@@ -1,5 +1,6 @@
 # `drill`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Mine blocks behind the initial mined block

--- a/docs/effects/all-effects/drop_item.md
+++ b/docs/effects/all-effects/drop_item.md
@@ -1,5 +1,6 @@
 # `drop_item`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Drops an item at a location

--- a/docs/effects/all-effects/drop_item_slot.md
+++ b/docs/effects/all-effects/drop_item_slot.md
@@ -1,5 +1,6 @@
 # `drop_item_slot`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Drops items from the player's inventory

--- a/docs/effects/all-effects/drop_pickup_item.md
+++ b/docs/effects/all-effects/drop_pickup_item.md
@@ -1,11 +1,13 @@
 # `drop_pickup_item`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Drops an item that runs a chain on pickup
 
-**Requires Paper**
+:::warningRequires:
+Paper
+:::
 
 # Effect Syntax
 

--- a/docs/effects/all-effects/drop_random_item.md
+++ b/docs/effects/all-effects/drop_random_item.md
@@ -1,5 +1,6 @@
 # `drop_random_item`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Drops a random item at a location

--- a/docs/effects/all-effects/drop_weighted_random_item.md
+++ b/docs/effects/all-effects/drop_weighted_random_item.md
@@ -1,5 +1,6 @@
 # `drop_weighted_random_item`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Drops a random item at a location, with weighting for different items

--- a/docs/effects/all-effects/elytra_boost_save_chance.md
+++ b/docs/effects/all-effects/elytra_boost_save_chance.md
@@ -1,5 +1,6 @@
 # `elytra_boost_save_chance`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Prevents consuming fireworks when boosting with an elytra

--- a/docs/effects/all-effects/entity_reach.md
+++ b/docs/effects/all-effects/entity_reach.md
@@ -1,10 +1,13 @@
 # `entity_reach`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Adds reach for interacting with entities
 
-**Requires 1.21+**
+:::warningRequires:
+Server Version 1.21+
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/explosion_knockback_resistance_multiplier.md
+++ b/docs/effects/all-effects/explosion_knockback_resistance_multiplier.md
@@ -1,10 +1,13 @@
 # `explosion_knockback_resistance_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies explosion resistance
 
-**Requires 1.21+**
+:::warningRequires:
+Server Version 1.21+
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/extinguish.md
+++ b/docs/effects/all-effects/extinguish.md
@@ -1,5 +1,6 @@
 # `extinguish`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Extinguish the player

--- a/docs/effects/all-effects/feather_step.md
+++ b/docs/effects/all-effects/feather_step.md
@@ -1,5 +1,6 @@
 # `feather_step`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Prevents trampling crops

--- a/docs/effects/all-effects/flight.md
+++ b/docs/effects/all-effects/flight.md
@@ -1,5 +1,6 @@
 # `flight`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Grants flight

--- a/docs/effects/all-effects/food_multiplier.md
+++ b/docs/effects/all-effects/food_multiplier.md
@@ -1,5 +1,6 @@
 # `food_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies food gain from eating

--- a/docs/effects/all-effects/gain_task_xp.md
+++ b/docs/effects/all-effects/gain_task_xp.md
@@ -1,11 +1,13 @@
 # `gain_task_xp`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gains experience points for a task in a quest, including multipliers.
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Effect Syntax
 

--- a/docs/effects/all-effects/give_battlepass_task_xp.md
+++ b/docs/effects/all-effects/give_battlepass_task_xp.md
@@ -1,10 +1,13 @@
 # `give_battlepass_task_xp`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a task in a quest, excluding multipliers.
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Effect Syntax
 ```yaml
 - id: give_battlepass_task_xp

--- a/docs/effects/all-effects/give_battlepass_tier.md
+++ b/docs/effects/all-effects/give_battlepass_tier.md
@@ -1,10 +1,13 @@
 # `give_battlepass_tier`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Give battlepass tiers to the player.
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Effect Syntax
 ```yaml
 - id: give_battlepass_tier

--- a/docs/effects/all-effects/give_battlepass_xp.md
+++ b/docs/effects/all-effects/give_battlepass_xp.md
@@ -1,10 +1,13 @@
 # `give_battlepass_xp`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Give battlepass experience points
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Effect Syntax
 ```yaml
 - id: give_battlepass_xp

--- a/docs/effects/all-effects/give_food.md
+++ b/docs/effects/all-effects/give_food.md
@@ -1,5 +1,6 @@
 # `give_food`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives the player food

--- a/docs/effects/all-effects/give_global_points.md
+++ b/docs/effects/all-effects/give_global_points.md
@@ -1,5 +1,6 @@
 # `give_global_points`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Add / subtract global points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)

--- a/docs/effects/all-effects/give_health.md
+++ b/docs/effects/all-effects/give_health.md
@@ -1,5 +1,6 @@
 # `give_health`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives the player health

--- a/docs/effects/all-effects/give_item.md
+++ b/docs/effects/all-effects/give_item.md
@@ -1,5 +1,6 @@
 # `give_item`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives a player an item

--- a/docs/effects/all-effects/give_item_points.md
+++ b/docs/effects/all-effects/give_item_points.md
@@ -1,5 +1,6 @@
 # `give_item_points`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Add / subtract item points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)

--- a/docs/effects/all-effects/give_job_xp.md
+++ b/docs/effects/all-effects/give_job_xp.md
@@ -1,10 +1,13 @@
 # `give_job_xp`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a certain job
 
-**Requires EcoJobs**
+:::warningRequires:
+EcoJobs
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/give_lands_balance.md
+++ b/docs/effects/all-effects/give_lands_balance.md
@@ -1,11 +1,13 @@
 # `give_lands_balance`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Give money to a Land's bank balance
 
-**Requires Lands**
+:::warningRequires:
+Lands
+:::
 
 # Effect Syntax
 

--- a/docs/effects/all-effects/give_magic.md
+++ b/docs/effects/all-effects/give_magic.md
@@ -1,10 +1,13 @@
 # `give_magic`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Add / subtract magic
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/give_mcmmo_xp.md
+++ b/docs/effects/all-effects/give_mcmmo_xp.md
@@ -1,10 +1,13 @@
 # `give_mcmmo_xp`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a certain skill
 
-**Requires mcMMO**
+:::warningRequires:
+McMMO
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/give_money.md
+++ b/docs/effects/all-effects/give_money.md
@@ -1,10 +1,13 @@
 # `give_money`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives a player money
 
-**Requires Vault economy**
+:::warningRequires:
+Vault
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/give_oxygen.md
+++ b/docs/effects/all-effects/give_oxygen.md
@@ -1,5 +1,6 @@
 # `give_oxygen`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Give a player oxygen

--- a/docs/effects/all-effects/give_permission.md
+++ b/docs/effects/all-effects/give_permission.md
@@ -1,10 +1,13 @@
 # `give_permission`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Gives a permission while active
 
-**Requires Vault**
+:::warningRequires:
+Vault
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/give_pet_xp.md
+++ b/docs/effects/all-effects/give_pet_xp.md
@@ -1,10 +1,13 @@
 # `give_pet_xp`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a certain pet
 
-**Requires EcoPets**
+:::warningRequires:
+EcoPets
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/give_points.md
+++ b/docs/effects/all-effects/give_points.md
@@ -1,5 +1,6 @@
 # `give_points`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Add / subtract points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)

--- a/docs/effects/all-effects/give_price.md
+++ b/docs/effects/all-effects/give_price.md
@@ -1,5 +1,6 @@
 # `give_price`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Pay a [price](https://plugins.auxilor.io/all-plugins/prices) to a player

--- a/docs/effects/all-effects/give_saturation.md
+++ b/docs/effects/all-effects/give_saturation.md
@@ -1,5 +1,6 @@
 # `give_saturation`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives the player saturation

--- a/docs/effects/all-effects/give_skill_xp.md
+++ b/docs/effects/all-effects/give_skill_xp.md
@@ -1,10 +1,13 @@
 # `give_skill_xp`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a certain skill
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/give_skill_xp_naturally.md
+++ b/docs/effects/all-effects/give_skill_xp_naturally.md
@@ -1,12 +1,15 @@
 # `give_skill_xp_naturally`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives naturally-gained experience points for a certain skill
 
 This will send a message to a player and will include multipliers.
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/give_task_xp.md
+++ b/docs/effects/all-effects/give_task_xp.md
@@ -1,11 +1,13 @@
 # `give_task_xp`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a task in a quest, excluding multipliers.
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Effect Syntax
 

--- a/docs/effects/all-effects/give_xp.md
+++ b/docs/effects/all-effects/give_xp.md
@@ -1,5 +1,6 @@
 # `give_xp`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points

--- a/docs/effects/all-effects/glow_nearby_blocks.md
+++ b/docs/effects/all-effects/glow_nearby_blocks.md
@@ -1,5 +1,6 @@
 # `glow_nearby_blocks`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Make nearby blocks of a certain type glow a certain color

--- a/docs/effects/all-effects/gravity_multiplier.md
+++ b/docs/effects/all-effects/gravity_multiplier.md
@@ -1,10 +1,13 @@
 # `gravity_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies gravity
 
-**Requires 1.21+**
+:::warningRequires:
+Server Version 1.21+
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/homing.md
+++ b/docs/effects/all-effects/homing.md
@@ -1,6 +1,6 @@
 # `homing`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Makes projectiles hone in onto entities (homing arrows / tridents)

--- a/docs/effects/all-effects/hunger_multiplier.md
+++ b/docs/effects/all-effects/hunger_multiplier.md
@@ -1,5 +1,6 @@
 # `hunger_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies hunger loss

--- a/docs/effects/all-effects/ignite.md
+++ b/docs/effects/all-effects/ignite.md
@@ -1,5 +1,6 @@
 # `ignite`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Lights the victim on fire

--- a/docs/effects/all-effects/increase_step_height.md
+++ b/docs/effects/all-effects/increase_step_height.md
@@ -1,10 +1,13 @@
 # `increase_step_height`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Increases the amount of blocks you can walk over without jumping
 
-**Requires 1.21+**
+:::warningRequires:
+Server Version 1.21+
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/inscribe_item.md
+++ b/docs/effects/all-effects/inscribe_item.md
@@ -1,11 +1,13 @@
 # `inscribe_item`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Inscribes an item with a scroll
 
-**Requires EcoScrolls**
+:::warningRequires:
+EcoScrolls
+:::
 
 # Effect Syntax
 

--- a/docs/effects/all-effects/item_durability_multiplier.md
+++ b/docs/effects/all-effects/item_durability_multiplier.md
@@ -1,5 +1,6 @@
 # `item_durability_multiplier`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Multiplies item durability (only works if holders are items, e.g. in EcoEnchants, EcoItems, etc.)

--- a/docs/effects/all-effects/job_xp_multiplier.md
+++ b/docs/effects/all-effects/job_xp_multiplier.md
@@ -1,10 +1,13 @@
 # `job_xp_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies job xp gain
 
-**Requires EcoJobs**
+:::warningRequires:
+EcoJobs
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/jobs_money_multiplier.md
+++ b/docs/effects/all-effects/jobs_money_multiplier.md
@@ -1,10 +1,14 @@
 # `jobs_money_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies money gain from jobs
 
-**Requires Jobs Reborn**
+
+:::warningRequires:
+Jobs Reborn
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/jobs_xp_multiplier.md
+++ b/docs/effects/all-effects/jobs_xp_multiplier.md
@@ -1,10 +1,14 @@
 # `jobs_xp_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies xp gain from jobs
 
-**Requires Jobs Reborn**
+
+:::warningRequires:
+Jobs Reborn
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/jump_strength_multiplier.md
+++ b/docs/effects/all-effects/jump_strength_multiplier.md
@@ -1,10 +1,13 @@
 # `jump_strength_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies jump strength
 
-**Requires 1.21+**
+:::warningRequires:
+Server Version 1.21+
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/keep_inventory.md
+++ b/docs/effects/all-effects/keep_inventory.md
@@ -1,5 +1,6 @@
 # `keep_inventory`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Gives the player keep inventory

--- a/docs/effects/all-effects/keep_level.md
+++ b/docs/effects/all-effects/keep_level.md
@@ -1,5 +1,6 @@
 # `keep_level`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Makes the player keep their XP level on death

--- a/docs/effects/all-effects/kick.md
+++ b/docs/effects/all-effects/kick.md
@@ -1,5 +1,6 @@
 # `kick`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Kicks the player

--- a/docs/effects/all-effects/knock_away.md
+++ b/docs/effects/all-effects/knock_away.md
@@ -1,5 +1,6 @@
 # `knock_away`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Knock the victim away from the player

--- a/docs/effects/all-effects/knockback_multiplier.md
+++ b/docs/effects/all-effects/knockback_multiplier.md
@@ -1,5 +1,6 @@
 # `knockback_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies attack knockback

--- a/docs/effects/all-effects/knockback_resistance_multiplier.md
+++ b/docs/effects/all-effects/knockback_resistance_multiplier.md
@@ -1,5 +1,6 @@
 # `knockback_resistance_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies knockback resistance

--- a/docs/effects/all-effects/level_item.md
+++ b/docs/effects/all-effects/level_item.md
@@ -1,5 +1,6 @@
 # `level_item`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gain item XP for a certain level

--- a/docs/effects/all-effects/luck_multiplier.md
+++ b/docs/effects/all-effects/luck_multiplier.md
@@ -1,5 +1,6 @@
 # `luck_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies luck

--- a/docs/effects/all-effects/magic_regen_multiplier.md
+++ b/docs/effects/all-effects/magic_regen_multiplier.md
@@ -1,10 +1,13 @@
 # `magic_regen_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies magic regeneration
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/make_skill_crit.md
+++ b/docs/effects/all-effects/make_skill_crit.md
@@ -1,10 +1,13 @@
 # `make_skill_crit`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Deal a crit hit
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/mcmmo_xp_multiplier.md
+++ b/docs/effects/all-effects/mcmmo_xp_multiplier.md
@@ -1,10 +1,13 @@
 # `mcmmo_xp_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies mcMMO skill xp gain
 
-**Requires mcMMO**
+:::warningRequires:
+McMMO
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/mine_radius.md
+++ b/docs/effects/all-effects/mine_radius.md
@@ -1,5 +1,6 @@
 # `mine_radius`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Mines a square radius around a block

--- a/docs/effects/all-effects/mine_radius_one_deep.md
+++ b/docs/effects/all-effects/mine_radius_one_deep.md
@@ -1,5 +1,6 @@
 # `mine_radius_one_deep`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Mines a square radius around a block, but only one block deep

--- a/docs/effects/all-effects/mine_vein.md
+++ b/docs/effects/all-effects/mine_vein.md
@@ -1,6 +1,6 @@
 # `mine_vein`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Mines a vein of blocks

--- a/docs/effects/all-effects/mining_efficiency.md
+++ b/docs/effects/all-effects/mining_efficiency.md
@@ -1,10 +1,13 @@
 # `mining_efficiency`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Adds mining efficiency (mining speed when using the correct tool)
 
-**Requires 1.21+**
+:::warningRequires:
+Server Version 1.21+
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/mining_speed_multiplier.md
+++ b/docs/effects/all-effects/mining_speed_multiplier.md
@@ -1,10 +1,13 @@
 # `mining_speed_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies mining speed
 
-**Requires 1.21+**
+:::warningRequires:
+Server Version 1.21+
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/mob_coins_chance_multiplier.md
+++ b/docs/effects/all-effects/mob_coins_chance_multiplier.md
@@ -1,10 +1,14 @@
 # `mob_coins_chance_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies the chance of mobcoins being dropped
 
-**Requires UltimateMobCoins**
+
+:::warningRequires:
+UltimateMobCoins
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/mob_coins_drop_multiplier.md
+++ b/docs/effects/all-effects/mob_coins_drop_multiplier.md
@@ -1,10 +1,14 @@
 # `mob_coins_drop_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies the mobcoins dropped
 
-**Requires UltimateMobCoins**
+
+:::warningRequires:
+UltimateMobCoins
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/mob_coins_multiplier.md
+++ b/docs/effects/all-effects/mob_coins_multiplier.md
@@ -1,10 +1,13 @@
 # `mob_coins_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies mob coin drops
 
-**Requires Flare Mobcoins**
+:::warningRequires:
+Flare Mobcoins
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/movement_efficiency_multiplier.md
+++ b/docs/effects/all-effects/movement_efficiency_multiplier.md
@@ -1,10 +1,13 @@
 # `movement_efficiency_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies movement speed through difficult terrain
 
-**Requires 1.21+**
+:::warningRequires:
+Server Version 1.21+
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/movement_speed_multiplier.md
+++ b/docs/effects/all-effects/movement_speed_multiplier.md
@@ -1,5 +1,6 @@
 # `movement_speed_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies movement speed

--- a/docs/effects/all-effects/multiply_all_stats.md
+++ b/docs/effects/all-effects/multiply_all_stats.md
@@ -1,10 +1,13 @@
 # `multiply_all_stats`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies all stats by a specific value
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/multiply_drops.md
+++ b/docs/effects/all-effects/multiply_drops.md
@@ -1,5 +1,6 @@
 # `multiply_drops`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Multiplies drops (requires a drop trigger)

--- a/docs/effects/all-effects/multiply_global_points.md
+++ b/docs/effects/all-effects/multiply_global_points.md
@@ -1,5 +1,6 @@
 # `multiply_global_points`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Multiply global points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)

--- a/docs/effects/all-effects/multiply_item_points.md
+++ b/docs/effects/all-effects/multiply_item_points.md
@@ -1,5 +1,6 @@
 # `multiply_item_points`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Multiply item points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)

--- a/docs/effects/all-effects/multiply_magic.md
+++ b/docs/effects/all-effects/multiply_magic.md
@@ -1,10 +1,13 @@
 # `multiply_magic`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Multiply magic
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/multiply_points.md
+++ b/docs/effects/all-effects/multiply_points.md
@@ -1,5 +1,6 @@
 # `multiply_points`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Multiply points (check the [points](https://plugins.auxilor.io/effects/points) wiki page if you don't know what these are)

--- a/docs/effects/all-effects/multiply_stat.md
+++ b/docs/effects/all-effects/multiply_stat.md
@@ -1,10 +1,13 @@
 # `multiply_stat`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies a stat by a specific value
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/multiply_stat_temporarily.md
+++ b/docs/effects/all-effects/multiply_stat_temporarily.md
@@ -1,10 +1,13 @@
 # `multiply_stat_temporarily`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Multiplies a stat by a specific value
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/multiply_velocity.md
+++ b/docs/effects/all-effects/multiply_velocity.md
@@ -1,5 +1,6 @@
 # `multiply_velocity`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Multiplies a players velocity

--- a/docs/effects/all-effects/name_entity.md
+++ b/docs/effects/all-effects/name_entity.md
@@ -1,5 +1,6 @@
 # `name_entity`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Set the display name of an entity

--- a/docs/effects/all-effects/open_crafting.md
+++ b/docs/effects/all-effects/open_crafting.md
@@ -1,6 +1,6 @@
 # `open_crafting`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Opens a crafting table for the player

--- a/docs/effects/all-effects/open_ender_chest.md
+++ b/docs/effects/all-effects/open_ender_chest.md
@@ -1,6 +1,6 @@
 # `open_ender_chest`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Opens the player's ender chest

--- a/docs/effects/all-effects/particle_animation.md
+++ b/docs/effects/all-effects/particle_animation.md
@@ -1,6 +1,6 @@
 # `particle_animation`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Plays a particle animation

--- a/docs/effects/all-effects/particle_line.md
+++ b/docs/effects/all-effects/particle_line.md
@@ -1,5 +1,6 @@
 # `particle_line`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Spawns a line of particles between you and the target location

--- a/docs/effects/all-effects/pay_price.md
+++ b/docs/effects/all-effects/pay_price.md
@@ -1,5 +1,6 @@
 # `pay_price`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Pay a [price](https://plugins.auxilor.io/all-plugins/prices)

--- a/docs/effects/all-effects/permanent_potion_effect.md
+++ b/docs/effects/all-effects/permanent_potion_effect.md
@@ -1,5 +1,6 @@
 # `permanent_potion_effect`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Gives a permanent [potion effect](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionEffectType.html)

--- a/docs/effects/all-effects/pet_xp_multiplier.md
+++ b/docs/effects/all-effects/pet_xp_multiplier.md
@@ -1,10 +1,13 @@
 # `pet_xp_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies pet xp gain
 
-**Requires EcoPets**
+:::warningRequires:
+EcoPets
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/piercing.md
+++ b/docs/effects/all-effects/piercing.md
@@ -1,6 +1,6 @@
 # `piercing`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Makes projectiles pass through other entities (collaterals), like the Piercing enchantment.

--- a/docs/effects/all-effects/play_animation.md
+++ b/docs/effects/all-effects/play_animation.md
@@ -1,10 +1,14 @@
 # `play_animation`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Plays a Model Engine animation (The entity must have a custom model active)
 
-**Requires Model Engine**
+
+:::warningRequires:
+Model Engine
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/play_sound.md
+++ b/docs/effects/all-effects/play_sound.md
@@ -1,5 +1,6 @@
 # `play_sound`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Plays a sound to the player

--- a/docs/effects/all-effects/potion_duration_multiplier.md
+++ b/docs/effects/all-effects/potion_duration_multiplier.md
@@ -1,5 +1,6 @@
 # `potion_duration_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies the duration of brewed potions

--- a/docs/effects/all-effects/potion_effect.md
+++ b/docs/effects/all-effects/potion_effect.md
@@ -1,5 +1,6 @@
 # `potion_effect`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives a [potion](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionEffectType.html) effect

--- a/docs/effects/all-effects/pull_in.md
+++ b/docs/effects/all-effects/pull_in.md
@@ -1,5 +1,6 @@
 # `pull_in`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Pull the victim towards the player

--- a/docs/effects/all-effects/pull_to_location.md
+++ b/docs/effects/all-effects/pull_to_location.md
@@ -1,5 +1,6 @@
 # `pull_to_location`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Get pulled to a location

--- a/docs/effects/all-effects/quest_xp_multiplier.md
+++ b/docs/effects/all-effects/quest_xp_multiplier.md
@@ -1,10 +1,13 @@
 # `quest_xp_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies quest xp gain
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/random_player.md
+++ b/docs/effects/all-effects/random_player.md
@@ -1,5 +1,6 @@
 # `random_player`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Runs effects for a random player on the server

--- a/docs/effects/all-effects/rapid_bows.md
+++ b/docs/effects/all-effects/rapid_bows.md
@@ -1,5 +1,6 @@
 # `rapid_bows`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Allows bows to be shot at full speed without pulling back as far

--- a/docs/effects/all-effects/reel_speed_multiplier.md
+++ b/docs/effects/all-effects/reel_speed_multiplier.md
@@ -1,5 +1,6 @@
 # `reel_speed_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies the speed at which you pull in entities and drops with fishing rods

--- a/docs/effects/all-effects/regen_multiplier.md
+++ b/docs/effects/all-effects/regen_multiplier.md
@@ -1,5 +1,6 @@
 # `regen_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies regen speed

--- a/docs/effects/all-effects/remove_boss_bar.md
+++ b/docs/effects/all-effects/remove_boss_bar.md
@@ -1,5 +1,6 @@
 # `remove_boss_bar`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Removes a boss bar

--- a/docs/effects/all-effects/remove_enchant.md
+++ b/docs/effects/all-effects/remove_enchant.md
@@ -1,5 +1,6 @@
 # `remove_enchant`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Removes an enchant from the item

--- a/docs/effects/all-effects/remove_item.md
+++ b/docs/effects/all-effects/remove_item.md
@@ -1,5 +1,6 @@
 # `remove_item`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Removes an item from the player's inventory

--- a/docs/effects/all-effects/remove_item_data.md
+++ b/docs/effects/all-effects/remove_item_data.md
@@ -1,5 +1,6 @@
 # `remove_item_data`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Remove item data

--- a/docs/effects/all-effects/remove_potion_effect.md
+++ b/docs/effects/all-effects/remove_potion_effect.md
@@ -1,5 +1,6 @@
 # `remove_potion_effect`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Removes a potion effect

--- a/docs/effects/all-effects/repair_item.md
+++ b/docs/effects/all-effects/repair_item.md
@@ -1,5 +1,6 @@
 # `repair_item`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Repairs the item

--- a/docs/effects/all-effects/replace_near.md
+++ b/docs/effects/all-effects/replace_near.md
@@ -1,5 +1,6 @@
 # `replace_near`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Replaces nearby blocks with other blocks

--- a/docs/effects/all-effects/replant_crops.md
+++ b/docs/effects/all-effects/replant_crops.md
@@ -1,5 +1,6 @@
 # `replant_crops`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Automatically replants crops

--- a/docs/effects/all-effects/rotate.md
+++ b/docs/effects/all-effects/rotate.md
@@ -1,5 +1,6 @@
 # `rotate`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Spin around

--- a/docs/effects/all-effects/rotate_victim.md
+++ b/docs/effects/all-effects/rotate_victim.md
@@ -1,5 +1,6 @@
 # `rotate_victim`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Spin the victim around

--- a/docs/effects/all-effects/run_chain.md
+++ b/docs/effects/all-effects/run_chain.md
@@ -1,5 +1,6 @@
 # `run_chain`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Execute an effect chain

--- a/docs/effects/all-effects/run_command.md
+++ b/docs/effects/all-effects/run_command.md
@@ -1,5 +1,6 @@
 # `run_command`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Runs a command from console

--- a/docs/effects/all-effects/run_player_command.md
+++ b/docs/effects/all-effects/run_player_command.md
@@ -1,5 +1,6 @@
 # `run_player_command`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Runs a command as a player

--- a/docs/effects/all-effects/safe_fall_distance.md
+++ b/docs/effects/all-effects/safe_fall_distance.md
@@ -1,10 +1,13 @@
 # `safe_fall_distance`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Increases/decreases the distance you can fall without taking damage
 
-**Requires 1.21+**
+:::warningRequires:
+Server Version 1.21+
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/scale.md
+++ b/docs/effects/all-effects/scale.md
@@ -1,10 +1,13 @@
 # `scale`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies scale
 
-**Requires 1.21+**
+:::warningRequires:
+Server Version 1.21+
+:::
 # Effect Syntax
 ```yaml
 - id: scale

--- a/docs/effects/all-effects/sell_items.md
+++ b/docs/effects/all-effects/sell_items.md
@@ -1,5 +1,6 @@
 # `sell_items`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Sells dropped items / item from trigger

--- a/docs/effects/all-effects/sell_multiplier.md
+++ b/docs/effects/all-effects/sell_multiplier.md
@@ -1,5 +1,6 @@
 # `sell_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies money gained from selling items

--- a/docs/effects/all-effects/send_message.md
+++ b/docs/effects/all-effects/send_message.md
@@ -1,5 +1,6 @@
 # `send_message`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Sends the player a message

--- a/docs/effects/all-effects/send_minimessage.md
+++ b/docs/effects/all-effects/send_minimessage.md
@@ -1,10 +1,13 @@
 # `send_minimessage`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Sends the player a minimessage message, supports clickable components, etc.
 
-**Requires Paper**
+:::warningRequires:
+Paper
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/send_title.md
+++ b/docs/effects/all-effects/send_title.md
@@ -1,5 +1,6 @@
 # `send_title`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Send a title/subtitle to the player

--- a/docs/effects/all-effects/set_armor_trim.md
+++ b/docs/effects/all-effects/set_armor_trim.md
@@ -1,5 +1,6 @@
 # `set_armor_trim`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Sets item armor trim

--- a/docs/effects/all-effects/set_battlepass_tier.md
+++ b/docs/effects/all-effects/set_battlepass_tier.md
@@ -1,10 +1,13 @@
 # `set_battlepass_tier`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Set the player's battlepass tier
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Effect Syntax
 ```yaml
 - id: set_battlepass_tier

--- a/docs/effects/all-effects/set_block.md
+++ b/docs/effects/all-effects/set_block.md
@@ -1,6 +1,6 @@
 # `set_block`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Set a block

--- a/docs/effects/all-effects/set_custom_model_data.md
+++ b/docs/effects/all-effects/set_custom_model_data.md
@@ -1,5 +1,6 @@
 # `set_custom_model_data`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Set the item's custom model data

--- a/docs/effects/all-effects/set_food.md
+++ b/docs/effects/all-effects/set_food.md
@@ -1,5 +1,6 @@
 # `set_food`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Sets the player's food

--- a/docs/effects/all-effects/set_freeze_ticks.md
+++ b/docs/effects/all-effects/set_freeze_ticks.md
@@ -1,5 +1,6 @@
 # `set_freeze_ticks`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Sets the victims freeze ticks (frost / powdered snow effect)

--- a/docs/effects/all-effects/set_global_points.md
+++ b/docs/effects/all-effects/set_global_points.md
@@ -1,5 +1,6 @@
 # `set_global_points`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Set global points (check the points wiki page if you don't know what these are)

--- a/docs/effects/all-effects/set_item_data.md
+++ b/docs/effects/all-effects/set_item_data.md
@@ -1,5 +1,6 @@
 # `set_item_data`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Set item data

--- a/docs/effects/all-effects/set_item_points.md
+++ b/docs/effects/all-effects/set_item_points.md
@@ -1,5 +1,6 @@
 # `set_item_points`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Set item points (check the points wiki page if you don't know what these are)

--- a/docs/effects/all-effects/set_lands_balance.md
+++ b/docs/effects/all-effects/set_lands_balance.md
@@ -1,11 +1,13 @@
 # `set_lands_balance`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Set the Land bank's balance
 
-**Requires Lands**
+:::warningRequires:
+Lands
+:::
 
 # Effect Syntax
 

--- a/docs/effects/all-effects/set_points.md
+++ b/docs/effects/all-effects/set_points.md
@@ -1,5 +1,6 @@
 # `set_points`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Set points (check the points wiki page if you don't know what these are)

--- a/docs/effects/all-effects/set_saturation.md
+++ b/docs/effects/all-effects/set_saturation.md
@@ -1,5 +1,6 @@
 # `set_saturation`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Sets the player's saturation

--- a/docs/effects/all-effects/set_velocity.md
+++ b/docs/effects/all-effects/set_velocity.md
@@ -1,5 +1,6 @@
 # `set_velocity`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Sets your velocity

--- a/docs/effects/all-effects/set_victim_velocity.md
+++ b/docs/effects/all-effects/set_victim_velocity.md
@@ -1,5 +1,6 @@
 # `set_victim_velocity`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Sets the victim's velocity

--- a/docs/effects/all-effects/shoot.md
+++ b/docs/effects/all-effects/shoot.md
@@ -1,5 +1,6 @@
 # `shoot`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Shoots a [projectile](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/Projectile.html)

--- a/docs/effects/all-effects/shoot_arrow.md
+++ b/docs/effects/all-effects/shoot_arrow.md
@@ -1,5 +1,6 @@
 # `shoot_arrow`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Shoots an arrow

--- a/docs/effects/all-effects/shuffle_hotbar.md
+++ b/docs/effects/all-effects/shuffle_hotbar.md
@@ -1,5 +1,6 @@
 # `shuffle_hotbar`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Shuffle your victim's hotbar

--- a/docs/effects/all-effects/skill_xp_multiplier.md
+++ b/docs/effects/all-effects/skill_xp_multiplier.md
@@ -1,10 +1,13 @@
 # `skill_xp_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies skill xp gain
 
-**Requires EcoSkills / AuraSkills*
+:::warningRequires:
+EcoSkills || AuraSkills
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/smite.md
+++ b/docs/effects/all-effects/smite.md
@@ -1,5 +1,6 @@
 # `smite`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Strikes lightning on a victim

--- a/docs/effects/all-effects/sneaking_speed_multiplier.md
+++ b/docs/effects/all-effects/sneaking_speed_multiplier.md
@@ -1,10 +1,13 @@
 # `sneaking_speed_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies sneaking speed
 
-**Requires 1.21+**
+:::warningRequires:
+Server Version 1.21+
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/spawn_entity.md
+++ b/docs/effects/all-effects/spawn_entity.md
@@ -1,5 +1,6 @@
 # `spawn_entity`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Spawns an [entity](https://plugins.auxilor.io/all-plugins/the-entity-lookup-system)

--- a/docs/effects/all-effects/spawn_mobs.md
+++ b/docs/effects/all-effects/spawn_mobs.md
@@ -1,5 +1,6 @@
 # `spawn_mobs`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Spawns [mobs](https://plugins.auxilor.io/all-plugins/the-entity-lookup-system) to help you

--- a/docs/effects/all-effects/spawn_particle.md
+++ b/docs/effects/all-effects/spawn_particle.md
@@ -1,5 +1,6 @@
 # `spawn_particle`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Spawns a [particle](https://plugins.auxilor.io/all-plugins/the-particle-lookup-system)

--- a/docs/effects/all-effects/spawn_potion_cloud.md
+++ b/docs/effects/all-effects/spawn_potion_cloud.md
@@ -1,5 +1,6 @@
 # `spawn_potion_cloud`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Spawns a [potion](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionEffectType.html) cloud

--- a/docs/effects/all-effects/start_quest.md
+++ b/docs/effects/all-effects/start_quest.md
@@ -1,11 +1,13 @@
 # `start_quest`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Starts a quest for the player
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Effect Syntax
 

--- a/docs/effects/all-effects/strike_lightning.md
+++ b/docs/effects/all-effects/strike_lightning.md
@@ -1,5 +1,6 @@
 # `strike_lightning`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Strikes lightning at a point

--- a/docs/effects/all-effects/strip_ai.md
+++ b/docs/effects/all-effects/strip_ai.md
@@ -1,5 +1,6 @@
 # `strip_ai`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Strips a mob's AI temporarily

--- a/docs/effects/all-effects/swarm.md
+++ b/docs/effects/all-effects/swarm.md
@@ -1,6 +1,6 @@
 # `swarm`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Makes nearby monsters in a certain radius attack the victim

--- a/docs/effects/all-effects/take_money.md
+++ b/docs/effects/all-effects/take_money.md
@@ -1,10 +1,13 @@
 # `take_money`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Takes money from the player
 
-**Requires Vault economy**
+:::warningRequires:
+Vault
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/target_player.md
+++ b/docs/effects/all-effects/target_player.md
@@ -1,6 +1,6 @@
 # `target_player`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Makes the victim target the player (requires the victim to be a monster)

--- a/docs/effects/all-effects/telekinesis.md
+++ b/docs/effects/all-effects/telekinesis.md
@@ -1,5 +1,6 @@
 # `telekinesis`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Teleports all drops to the player's inventory

--- a/docs/effects/all-effects/teleport.md
+++ b/docs/effects/all-effects/teleport.md
@@ -1,5 +1,6 @@
 # `teleport`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Teleports to a location

--- a/docs/effects/all-effects/teleport_to.md
+++ b/docs/effects/all-effects/teleport_to.md
@@ -1,5 +1,6 @@
 # `teleport_to`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Teleport a player to a specific location

--- a/docs/effects/all-effects/teleport_to_ground.md
+++ b/docs/effects/all-effects/teleport_to_ground.md
@@ -1,5 +1,6 @@
 # `teleport_to_ground`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Teleports to the ground

--- a/docs/effects/all-effects/total_damage_multiplier.md
+++ b/docs/effects/all-effects/total_damage_multiplier.md
@@ -1,5 +1,6 @@
 # `total_damage_multiplier`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Multiplies all incoming or outgoing damage from any damage trigger

--- a/docs/effects/all-effects/traceback.md
+++ b/docs/effects/all-effects/traceback.md
@@ -1,5 +1,6 @@
 # `traceback`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Go back to a previous position

--- a/docs/effects/all-effects/transmission.md
+++ b/docs/effects/all-effects/transmission.md
@@ -1,5 +1,6 @@
 # `transmission`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Teleport a player forward in the direction they're facing (Like AotE)

--- a/docs/effects/all-effects/trigger_custom.md
+++ b/docs/effects/all-effects/trigger_custom.md
@@ -1,5 +1,6 @@
 # `trigger_custom`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Call a custom trigger

--- a/docs/effects/all-effects/underwater_mining_speed_multiplier.md
+++ b/docs/effects/all-effects/underwater_mining_speed_multiplier.md
@@ -1,10 +1,13 @@
 # `underwater_mining_speed_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies underwater mining speed
 
-**Requires 1.21+**
+:::warningRequires:
+Server Version 1.21+
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/update_boss_bar.md
+++ b/docs/effects/all-effects/update_boss_bar.md
@@ -1,5 +1,6 @@
 # `update_boss_bar`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Updates a boss bar

--- a/docs/effects/all-effects/victim_speed_multiplier.md
+++ b/docs/effects/all-effects/victim_speed_multiplier.md
@@ -1,5 +1,6 @@
 # `victim_speed_multiplier`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Temporarily multiplies victim movement speed

--- a/docs/effects/all-effects/water_movement_efficiency_multiplier.md
+++ b/docs/effects/all-effects/water_movement_efficiency_multiplier.md
@@ -1,10 +1,13 @@
 # `water_movement_efficiency_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies water movement efficiency
 
-**Requires 1.21+**
+:::warningRequires:
+Server Version 1.21+
+:::
 
 # Effect Syntax
 ```yaml

--- a/docs/effects/all-effects/xp_multiplier.md
+++ b/docs/effects/all-effects/xp_multiplier.md
@@ -1,5 +1,6 @@
 # `xp_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies incoming xp gain

--- a/docs/effects/all-filters/at_war_with_victim.md
+++ b/docs/effects/all-filters/at_war_with_victim.md
@@ -2,7 +2,9 @@
 
 Requires the player is in a declared war with the victim
 
-**Requires Lands**
+:::warningRequires:
+Lands
+:::
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/battlepass_reward.md
+++ b/docs/effects/all-filters/battlepass_reward.md
@@ -2,7 +2,9 @@
 
 The list of battlepass rewards the effect should activate on
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/battlepass_task.md
+++ b/docs/effects/all-filters/battlepass_task.md
@@ -2,7 +2,9 @@
 
 The list of battlepass rewards the effect should activate on
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/custom_crop_stage.md
+++ b/docs/effects/all-filters/custom_crop_stage.md
@@ -2,7 +2,9 @@
 
 The list of crop stages the effect should activate on
 
-**Requires CustomCrops**
+:::warningRequires:
+CustomCrops
+:::
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/custom_crop_type.md
+++ b/docs/effects/all-filters/custom_crop_type.md
@@ -2,7 +2,9 @@
 
 The list of crop types the effect should activate on
 
-**Requires CustomCrops**
+:::warningRequires:
+CustomCrops
+:::
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/custom_fish_type.md
+++ b/docs/effects/all-filters/custom_fish_type.md
@@ -2,7 +2,9 @@
 
 The list of fish types the effect should activate on
 
-**Requires CustomFishing**
+:::warningRequires:
+CustomFishing
+:::
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/envoy_type.md
+++ b/docs/effects/all-filters/envoy_type.md
@@ -2,7 +2,9 @@
 
 The list of envoy types that the effect should activate against
 
-**Requires AxEnvoy**
+:::warningRequires:
+AxEnvoy
+:::
 
 # Filter Syntax
 ```yaml

--- a/docs/effects/all-filters/fertilizer_type.md
+++ b/docs/effects/all-filters/fertilizer_type.md
@@ -2,7 +2,9 @@
 
 The list of fertilizers the effect should activate on
 
-**Requires CustomCrops**
+:::warningRequires:
+CustomCrops
+:::
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/job.md
+++ b/docs/effects/all-filters/job.md
@@ -2,7 +2,9 @@
 
 Require a certain job
 
-**Requires EcoJobs**
+:::warningRequires:
+EcoJobs
+:::
 
 # Filter Syntax
 ```yaml

--- a/docs/effects/all-filters/magic_type.md
+++ b/docs/effects/all-filters/magic_type.md
@@ -2,7 +2,9 @@
 
 Require a certain magic type
 
-**Requires EcoSkills**
+:::warningRequires:
+EcoSkills
+:::
 
 # Filter Syntax
 ```yaml

--- a/docs/effects/all-filters/npc.md
+++ b/docs/effects/all-filters/npc.md
@@ -2,7 +2,9 @@
 
 Require a certain NPC
 
-**Requires Citizens || FancyNpcs**
+:::warningRequires:
+Citizens || FancyNpcs
+:::
 
 # Filter Syntax
 

--- a/docs/effects/all-filters/pet.md
+++ b/docs/effects/all-filters/pet.md
@@ -2,7 +2,9 @@
 
 Require a certain pet
 
-**Requires EcoPets**
+:::warningRequires:
+EcoPets
+:::
 
 # Filter Syntax
 ```yaml

--- a/docs/effects/all-filters/quest.md
+++ b/docs/effects/all-filters/quest.md
@@ -2,7 +2,9 @@
 
 Require a certain quest
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Filter Syntax
 ```yaml

--- a/docs/effects/all-filters/region.md
+++ b/docs/effects/all-filters/region.md
@@ -2,7 +2,10 @@
 
 Require a certain region
 
-**Requires WorldGuard**
+
+:::warningRequires:
+WorldGuard
+:::
 
 # Filter Syntax
 ```yaml

--- a/docs/effects/all-filters/scroll.md
+++ b/docs/effects/all-filters/scroll.md
@@ -2,7 +2,9 @@
 
 Require a certain scroll
 
-**Requires EcoScrolls**
+:::warningRequires:
+EcoScrolls
+:::
 
 # Filter Syntax
 ```yaml

--- a/docs/effects/all-filters/shop_item.md
+++ b/docs/effects/all-filters/shop_item.md
@@ -2,7 +2,9 @@
 
 Require a certain shop item
 
-**Requires EcoShop**
+:::warningRequires:
+EcoShop
+:::
 
 # Filter Syntax
 ```yaml

--- a/docs/effects/all-filters/skill.md
+++ b/docs/effects/all-filters/skill.md
@@ -2,7 +2,9 @@
 
 Require a certain skill
 
-**Requires EcoSkills or McMMO**
+:::warningRequires:
+EcoSkills || McMMO
+:::
 
 # Filter Syntax
 ```yaml

--- a/docs/effects/all-filters/task.md
+++ b/docs/effects/all-filters/task.md
@@ -2,7 +2,9 @@
 
 Require a certain task
 
-**Requires EcoQuests**
+:::warningRequires:
+EcoQuests
+:::
 
 # Filter Syntax
 ```yaml

--- a/docs/effects/all-filters/town_role.md
+++ b/docs/effects/all-filters/town_role.md
@@ -2,7 +2,9 @@
 
 The list of town roles the effect should activate on
 
-**Requires HuskTowns**
+:::warningRequires:
+HuskTowns
+:::
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/vote_service.md
+++ b/docs/effects/all-filters/vote_service.md
@@ -2,7 +2,10 @@
 
 The list of vote services that the effect should activate on
 
-**Requires NuVotifier**
+
+:::warningRequires:
+Votifier
+:::
 
 # Filter Syntax
 ```yaml

--- a/docs/effects/all-filters/watering_can_type.md
+++ b/docs/effects/all-filters/watering_can_type.md
@@ -2,7 +2,9 @@
 
 The list of watering cans the effect should activate on
 
-**Requires CustomCrops**
+:::warningRequires:
+CustomCrops
+:::
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-triggers.md
+++ b/docs/effects/all-triggers.md
@@ -31,7 +31,9 @@ Triggered effects also produce a value, and some product an alt-value, which can
 | `claim_battlepass_reward`       | Triggered when claiming a battlepass reward **Requires xBattlepass**                                              | 1                                             | -               |
 | `click_block`                   | Triggered when right-clicking on a block                                                                          | 1                                             | -               |
 | `click_entity`                  | Triggered when right-clicking on an entity                                                                        | 1                                             | -               |
-| `collect_envoy`                 | Triggered when collecting an envoy crate **Requires AxEnvoy**                                                     | 1                                             | -               |
+| `collect_envoy`                 | Triggered when collecting an envoy crate :::warningRequires:
+AxEnvoy
+:::                                                     | 1                                             | -               |
 | `complete_advancement`          | Triggered when completing an advancement                                                                          | 1                                             | -               |
 | `complete_battlepass_task`      | Triggered when completing a battlepass task **Requires xBattlepass**                                              | 1                                             | -               |
 | `complete_quest`                | Triggered when completing a quest **Requires EcoQuests**                                                          | 1                                             | -               |

--- a/docs/effects/external-integrations/auraskills/conditions/has_mana.md
+++ b/docs/effects/external-integrations/auraskills/conditions/has_mana.md
@@ -2,7 +2,9 @@
 
 Requires a player to have amount of mana
 
-**Requires AuraSkills**
+:::warningRequires:
+AuraSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/auraskills/conditions/has_skill_level.md
+++ b/docs/effects/external-integrations/auraskills/conditions/has_skill_level.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain skill level
 
-**Requires EcoSkills or AuraSkills**
+:::warningRequires:
+EcoSkills || AuraSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/auraskills/effects/add_stat.md
+++ b/docs/effects/external-integrations/auraskills/effects/add_stat.md
@@ -1,10 +1,13 @@
 # `add_stat`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Adds a value to a specific stat
 
-**Requires EcoSkills / AuraSkills**
+:::warningRequirements:
+EcoSkills || AuraSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/auraskills/effects/skill_xp_multiplier.md
+++ b/docs/effects/external-integrations/auraskills/effects/skill_xp_multiplier.md
@@ -1,10 +1,13 @@
 # `skill_xp_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies skill xp gain
 
-**Requires EcoSkills / AuraSkills**
+:::warningRequires:
+EcoSkills || AuraSkills
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/axenvoy/filters/envoy_type.md
+++ b/docs/effects/external-integrations/axenvoy/filters/envoy_type.md
@@ -2,7 +2,9 @@
 
 The list of envoy types that the effect should activate against
 
-**Requires AxEnvoy**
+:::warningRequires:
+AxEnvoy
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/citizens/filters/npc.md
+++ b/docs/effects/external-integrations/citizens/filters/npc.md
@@ -2,7 +2,9 @@
 
 Require a certain NPC
 
-**Requires Citizens || FancyNpcs**
+:::warningRequires:
+Citizens || FancyNpcs
+:::
 
 # Example Config
 

--- a/docs/effects/external-integrations/customcrops/conditions/is_season.md
+++ b/docs/effects/external-integrations/customcrops/conditions/is_season.md
@@ -2,7 +2,9 @@
 
 Requires it to be a certain season
 
-**Requires CustomCrops**
+:::warningRequires:
+CustomCrops
+:::
 # Example Config
 ```yaml
 - id: is_season

--- a/docs/effects/external-integrations/customcrops/filters/custom_crop_stage.md
+++ b/docs/effects/external-integrations/customcrops/filters/custom_crop_stage.md
@@ -2,7 +2,9 @@
 
 The list of crop stages the effect should activate on
 
-**Requires CustomCrops**
+:::warningRequires:
+CustomCrops
+:::
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/customcrops/filters/custom_crop_type.md
+++ b/docs/effects/external-integrations/customcrops/filters/custom_crop_type.md
@@ -2,7 +2,9 @@
 
 The list of crop types the effect should activate on
 
-**Requires CustomCrops**
+:::warningRequires:
+CustomCrops
+:::
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/customcrops/filters/fertilizer_type.md
+++ b/docs/effects/external-integrations/customcrops/filters/fertilizer_type.md
@@ -2,7 +2,9 @@
 
 The list of fertilizers the effect should activate on
 
-**Requires CustomCrops**
+:::warningRequires:
+CustomCrops
+:::
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/customcrops/filters/watering_can_type.md
+++ b/docs/effects/external-integrations/customcrops/filters/watering_can_type.md
@@ -2,7 +2,9 @@
 
 The list of watering cans the effect should activate on
 
-**Requires CustomCrops**
+:::warningRequires:
+CustomCrops
+:::
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/customfishing/filters/custom_fish_type.md
+++ b/docs/effects/external-integrations/customfishing/filters/custom_fish_type.md
@@ -2,7 +2,9 @@
 
 The list of fish types the effect should activate on
 
-**Requires CustomFishing**
+:::warningRequires:
+CustomFishing
+:::
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/fancynpcs/filters/npc.md
+++ b/docs/effects/external-integrations/fancynpcs/filters/npc.md
@@ -2,7 +2,9 @@
 
 Require a certain NPC
 
-**Requires Citizens || FancyNpcs**
+:::warningRequires:
+Citizens || FancyNpcs
+:::
 
 # Example Config
 

--- a/docs/effects/external-integrations/flaremobcoins/effects/mob_coins_multiplier.md
+++ b/docs/effects/external-integrations/flaremobcoins/effects/mob_coins_multiplier.md
@@ -1,10 +1,13 @@
 # `mob_coins_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies mob coin drops
 
-**Requires Flare Mobcoins**
+:::warningRequires:
+Flare Mobcoins
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/huskclaims/conditions/in_own_claim.md
+++ b/docs/effects/external-integrations/huskclaims/conditions/in_own_claim.md
@@ -2,7 +2,9 @@
 
 Requires the player to be in their own claim
 
-**Requires HuskClaims or HuskTowns**
+:::warningRequires:
+HuskClaims || HuskTowns || Lands
+:::
 # Example Config
 ```yaml
 - id: in_own_claim

--- a/docs/effects/external-integrations/husktowns/conditions/has_town_role.md
+++ b/docs/effects/external-integrations/husktowns/conditions/has_town_role.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain role in a town
 
-**Requires HuskTowns**
+:::warningRequires:
+HuskTowns
+:::
 # Example Config
 ```yaml
 - id: has_town_role

--- a/docs/effects/external-integrations/husktowns/conditions/in_own_claim.md
+++ b/docs/effects/external-integrations/husktowns/conditions/in_own_claim.md
@@ -2,7 +2,9 @@
 
 Requires the player to be in their own claim
 
-**Requires HuskClaims or HuskTowns**
+:::warningRequires:
+HuskClaims || HuskTowns || Lands
+:::
 # Example Config
 ```yaml
 - id: in_own_claim

--- a/docs/effects/external-integrations/husktowns/filters/town_role.md
+++ b/docs/effects/external-integrations/husktowns/filters/town_role.md
@@ -2,7 +2,9 @@
 
 The list of town roles the effect should activate on
 
-**Requires HuskTowns**
+:::warningRequires:
+HuskTowns
+:::
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/jobs-reborn/effects/jobs_money_multiplier.md
+++ b/docs/effects/external-integrations/jobs-reborn/effects/jobs_money_multiplier.md
@@ -1,10 +1,14 @@
 # `jobs_money_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies money gain from jobs
 
-**Requires Jobs Reborn**
+
+:::warningRequires:
+Jobs Reborn
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/jobs-reborn/effects/jobs_xp_multiplier.md
+++ b/docs/effects/external-integrations/jobs-reborn/effects/jobs_xp_multiplier.md
@@ -1,10 +1,14 @@
 # `jobs_xp_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies xp gain from jobs
 
-**Requires Jobs Reborn**
+
+:::warningRequires:
+Jobs Reborn
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/lands/conditions/has_lands_role.md
+++ b/docs/effects/external-integrations/lands/conditions/has_lands_role.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain role in the Land
 
-**Requires Lands**
+:::warningRequires:
+Lands
+:::
 # Example Config
 ```yaml
 - id: has_lands_role

--- a/docs/effects/external-integrations/lands/conditions/in_own_claim.md
+++ b/docs/effects/external-integrations/lands/conditions/in_own_claim.md
@@ -2,7 +2,9 @@
 
 Requires the player to be in their own claim
 
-**Requires HuskClaims, HuskTowns or Lands**
+:::warningRequires:
+HuskClaims || HuskTowns || Lands
+:::
 # Example Config
 ```yaml
 - id: in_own_claim

--- a/docs/effects/external-integrations/lands/conditions/in_trusted_claim.md
+++ b/docs/effects/external-integrations/lands/conditions/in_trusted_claim.md
@@ -2,7 +2,9 @@
 
 Requires the player to be in a claim they're trusted in
 
-**Requires Lands**
+:::warningRequires:
+Lands
+:::
 # Example Config
 ```yaml
 - id: in_trusted_claim

--- a/docs/effects/external-integrations/lands/conditions/lands_balance_above.md
+++ b/docs/effects/external-integrations/lands/conditions/lands_balance_above.md
@@ -2,7 +2,9 @@
 
 Requires the Land's bank balance to be above a value
 
-**Requires Lands**
+:::warningRequires:
+Lands
+:::
 # Example Config
 ```yaml
 - id: lands_balance_above

--- a/docs/effects/external-integrations/lands/conditions/lands_balance_below.md
+++ b/docs/effects/external-integrations/lands/conditions/lands_balance_below.md
@@ -2,7 +2,9 @@
 
 Requires the Land's bank balance to be below a value
 
-**Requires Lands**
+:::warningRequires:
+Lands
+:::
 # Example Config
 ```yaml
 - id: lands_balance_below

--- a/docs/effects/external-integrations/lands/conditions/lands_balance_equal.md
+++ b/docs/effects/external-integrations/lands/conditions/lands_balance_equal.md
@@ -2,7 +2,9 @@
 
 Requires the Land's bank balance to be equal to a value
 
-**Requires Lands**
+:::warningRequires:
+Lands
+:::
 # Example Config
 ```yaml
 - id: lands_balance_equal

--- a/docs/effects/external-integrations/lands/effects/give_lands_balance.md
+++ b/docs/effects/external-integrations/lands/effects/give_lands_balance.md
@@ -1,11 +1,13 @@
 # `give_lands_balance`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Give money to a Land's bank balance
 
-**Requires Lands**
+:::warningRequires:
+Lands
+:::
 
 # Example Config
 

--- a/docs/effects/external-integrations/lands/effects/set_lands_balance.md
+++ b/docs/effects/external-integrations/lands/effects/set_lands_balance.md
@@ -1,11 +1,13 @@
 # `set_lands_balance`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Set the Land bank's balance
 
-**Requires Lands**
+:::warningRequires:
+Lands
+:::
 
 # Example Config
 

--- a/docs/effects/external-integrations/lands/filters/at_war_with_victim.md
+++ b/docs/effects/external-integrations/lands/filters/at_war_with_victim.md
@@ -2,7 +2,9 @@
 
 Requires the player is in a declared war with the victim
 
-**Requires Lands**
+:::warningRequires:
+Lands
+:::
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/mcmmo/conditions/has_mcmmo_level.md
+++ b/docs/effects/external-integrations/mcmmo/conditions/has_mcmmo_level.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain McMMO skill level
 
-**Requires McMMO**
+:::warningRequires:
+McMMO
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/mcmmo/conditions/mcmmo_ability_on_cooldown.md
+++ b/docs/effects/external-integrations/mcmmo/conditions/mcmmo_ability_on_cooldown.md
@@ -2,7 +2,9 @@
 
 Requires an McMMO ability to be on cooldown
 
-**Requires McMMO**
+:::warningRequires:
+McMMO
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/mcmmo/effects/give_mcmmo_xp.md
+++ b/docs/effects/external-integrations/mcmmo/effects/give_mcmmo_xp.md
@@ -1,10 +1,13 @@
 # `give_mcmmo_xp`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a certain skill
 
-**Requires mcMMO**
+:::warningRequires:
+McMMO
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/mcmmo/effects/mcmmo_xp_multiplier.md
+++ b/docs/effects/external-integrations/mcmmo/effects/mcmmo_xp_multiplier.md
@@ -1,10 +1,13 @@
 # `mcmmo_xp_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies mcMMO skill xp gain
 
-**Requires mcMMO**
+:::warningRequires:
+McMMO
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/mcmmo/filters/mcmmo_ability.md
+++ b/docs/effects/external-integrations/mcmmo/filters/mcmmo_ability.md
@@ -2,6 +2,10 @@
 
 The list of [entities](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html) that the effect should activate against
 
+:::warningRequires:
+Lands
+:::
+
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/mcmmo/filters/skill.md
+++ b/docs/effects/external-integrations/mcmmo/filters/skill.md
@@ -2,7 +2,9 @@
 
 Require a certain skill
 
-**Requires EcoSkills or McMMO**
+:::warningRequires:
+EcoSkills || McMMO
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/modelengine/effects/play_animation.md
+++ b/docs/effects/external-integrations/modelengine/effects/play_animation.md
@@ -1,10 +1,14 @@
 # `play_animation`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Plays a Model Engine animation (The entity must have a custom model active)
 
-**Requires Model Engine**
+
+:::warningRequires:
+Model Engine
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/paper/conditions/in_bubble.md
+++ b/docs/effects/external-integrations/paper/conditions/in_bubble.md
@@ -2,7 +2,9 @@
 
 Requires a player to be in a bubble column
 
-**Requires Paper**
+:::warningRequires:
+Paper
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/paper/conditions/in_lava.md
+++ b/docs/effects/external-integrations/paper/conditions/in_lava.md
@@ -2,7 +2,9 @@
 
 Requires a player to be in lava
 
-**Requires Paper**
+:::warningRequires:
+Paper
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/paper/conditions/in_rain.md
+++ b/docs/effects/external-integrations/paper/conditions/in_rain.md
@@ -2,7 +2,9 @@
 
 Requires a player to be in rain
 
-**Requires Paper**
+:::warningRequires:
+Paper
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/paper/effects/drop_pickup_item.md
+++ b/docs/effects/external-integrations/paper/effects/drop_pickup_item.md
@@ -1,11 +1,13 @@
 # `drop_pickup_item`
-
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Drops an item that runs a chain on pickup
 
-**Requires Paper**
+:::warningRequires:
+Paper
+:::
 
 # Example Config
 

--- a/docs/effects/external-integrations/paper/effects/elytra_boost_save_chance.md
+++ b/docs/effects/external-integrations/paper/effects/elytra_boost_save_chance.md
@@ -1,5 +1,6 @@
 # `elytra_boost_save_chance`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Prevents consuming fireworks when boosting with an elytra

--- a/docs/effects/external-integrations/paper/effects/send_minimessage.md
+++ b/docs/effects/external-integrations/paper/effects/send_minimessage.md
@@ -1,10 +1,13 @@
 # `send_minimessage`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Sends the player a minimessage message, supports clickable components, etc.
 
-**Requires Paper**
+:::warningRequires:
+Paper
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/tab/conditions/has_boss_bar_visible.md
+++ b/docs/effects/external-integrations/tab/conditions/has_boss_bar_visible.md
@@ -2,7 +2,9 @@
 
 Requires a player to have the TAB boss bar shown to them
 
-**Requires TAB**
+:::warningRequires:
+TAB
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/tab/conditions/has_scoreboard_visible.md
+++ b/docs/effects/external-integrations/tab/conditions/has_scoreboard_visible.md
@@ -2,7 +2,9 @@
 
 Requires a player to have the TAB scoreboard shown to them
 
-**Requires TAB**
+:::warningRequires:
+TAB
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/ultimatemobcoins/effects/mob_coins_chance_multiplier.md
+++ b/docs/effects/external-integrations/ultimatemobcoins/effects/mob_coins_chance_multiplier.md
@@ -1,10 +1,14 @@
 # `mob_coins_chance_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies the chance of mobcoins being dropped
 
-**Requires UltimateMobCoins**
+
+:::warningRequires:
+UltimateMobCoins
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/ultimatemobcoins/effects/mob_coins_drop_multiplier.md
+++ b/docs/effects/external-integrations/ultimatemobcoins/effects/mob_coins_drop_multiplier.md
@@ -1,10 +1,14 @@
 # `mob_coins_drop_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies the mobcoins dropped
 
-**Requires UltimateMobCoins**
+
+:::warningRequires:
+UltimateMobCoins
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/vault/effects/give_permission.md
+++ b/docs/effects/external-integrations/vault/effects/give_permission.md
@@ -1,10 +1,13 @@
 # `give_permission`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Gives a permission while active
 
-**Requires Vault**
+:::warningRequires:
+Vault
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/votifier/filters/vote_service.md
+++ b/docs/effects/external-integrations/votifier/filters/vote_service.md
@@ -2,7 +2,10 @@
 
 The list of vote services that the effect should activate on
 
-**Requires NuVotifier**
+
+:::warningRequires:
+Votifier
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/worldguard/conditions/in_region.md
+++ b/docs/effects/external-integrations/worldguard/conditions/in_region.md
@@ -2,7 +2,10 @@
 
 Requires a player to be in a certain region
 
-**Requires WorldGuard**
+
+:::warningRequires:
+WorldGuard
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/worldguard/filters/region.md
+++ b/docs/effects/external-integrations/worldguard/filters/region.md
@@ -2,7 +2,10 @@
 
 Require a certain region
 
-**Requires WorldGuard**
+
+:::warningRequires:
+WorldGuard
+:::
 
 # Example Config
 ```yaml

--- a/docs/effects/external-integrations/xbattlepass/conditions/has_battlepass_tier.md
+++ b/docs/effects/external-integrations/xbattlepass/conditions/has_battlepass_tier.md
@@ -2,7 +2,9 @@
 
 Requires a player to have a certain battlepass tier
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Example Config
 ```yaml
 - id: has_battlepass_tier

--- a/docs/effects/external-integrations/xbattlepass/conditions/has_premium_battlepass.md
+++ b/docs/effects/external-integrations/xbattlepass/conditions/has_premium_battlepass.md
@@ -2,7 +2,9 @@
 
 Requires a player to have the premium battlepass
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Example Config
 ```yaml
 - id: has_premium_battlepass

--- a/docs/effects/external-integrations/xbattlepass/effects/battlepass_task_xp_multiplier.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/battlepass_task_xp_multiplier.md
@@ -1,10 +1,13 @@
 # `battlepass_task_xp_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies incoming battlepass task xp gain
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Example Config
 ```yaml
 - id: battlepass_task_xp_multiplier

--- a/docs/effects/external-integrations/xbattlepass/effects/battlepass_xp_multiplier.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/battlepass_xp_multiplier.md
@@ -1,10 +1,13 @@
 # `battlepass_xp_multiplier`
 :::infoPermanent Effect
+This effect is permanent and does not require a trigger.
 :::
 
 Multiplies incoming battlepass xp gain
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Example Config
 ```yaml
 - id: battlepassxp_multiplier

--- a/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_task_xp.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_task_xp.md
@@ -1,10 +1,13 @@
 # `give_battlepass_task_xp`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a task in a quest, excluding multipliers.
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Example Config
 ```yaml
 - id: give_battlepass_task_xp

--- a/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_tier.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_tier.md
@@ -1,10 +1,13 @@
 # `give_battlepass_tier`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Give battlepass tiers to the player.
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Example Config
 ```yaml
 - id: give_battlepass_tier

--- a/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_xp.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_xp.md
@@ -1,10 +1,13 @@
 # `give_battlepass_xp`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Give battlepass experience points
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Example Config
 ```yaml
 - id: give_battlepass_xp

--- a/docs/effects/external-integrations/xbattlepass/effects/set_battlepass_tier.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/set_battlepass_tier.md
@@ -1,10 +1,13 @@
 # `set_battlepass_tier`
 :::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Set the player's battlepass tier
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Example Config
 ```yaml
 - id: set_battlepass_tier

--- a/docs/effects/external-integrations/xbattlepass/filters/battlepass_reward.md
+++ b/docs/effects/external-integrations/xbattlepass/filters/battlepass_reward.md
@@ -2,7 +2,9 @@
 
 The list of battlepass rewards the effect should activate on
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/xbattlepass/filters/battlepass_task.md
+++ b/docs/effects/external-integrations/xbattlepass/filters/battlepass_task.md
@@ -2,7 +2,9 @@
 
 The list of battlepass rewards the effect should activate on
 
-**Requires xBattlepass**
+:::warningRequires:
+xBattlepass
+:::
 # Example Config
 ```yaml
 filters:

--- a/docs/reforges/reforges-effects/conditions/has_reforge.md
+++ b/docs/reforges/reforges-effects/conditions/has_reforge.md
@@ -2,7 +2,10 @@
 
 Requires a player to have a certain reforge active
 
-**Requires Reforges**
+
+:::warningRequires:
+Reforges
+:::
 
 # Example Config
 ```yaml

--- a/docs/talismans/talismans-effects/conditions/has_talisman.md
+++ b/docs/talismans/talismans-effects/conditions/has_talisman.md
@@ -2,7 +2,10 @@
 
 Requires a player to have a certain talisman active
 
-**Requires Talismans**
+
+:::warningRequires:
+Talismans
+:::
 
 # Example Config
 ```yaml


### PR DESCRIPTION
Replaced bold plugin requirement notes with consistent admonition blocks (e.g., :::warningRequires) across all plugin documentation. Updated effect type headers to use admonition blocks for 'Triggered Effect' and 'Permanent Effect' where appropriate. Fixed a copy-paste error in the EcoPets filter, correcting the required plugin from EcoJobs to EcoPets.