### PR TITLE
Change 'dangerRequires' to 'infoRequires' in docs

### DIFF
--- a/docs/all-plugins/custom-entity-ai/all-entity-goals/ecomobs_random_teleport.md
+++ b/docs/all-plugins/custom-entity-ai/all-entity-goals/ecomobs_random_teleport.md
@@ -2,7 +2,7 @@
 
 Allows a mob to teleport around randomly
 
-:::dangerRequires:
+:::infoRequires:
 EcoMobs
 :::
 

--- a/docs/boosters/boosters-effects/conditions/is_booster_active.md
+++ b/docs/boosters/boosters-effects/conditions/is_booster_active.md
@@ -2,7 +2,7 @@
 
 Requires a certain booster to be active on the server
 
-:::dangerRequires:
+:::infoRequires:
 Boosters
 :::
 

--- a/docs/ecoarmor/ecoarmor-effects/conditions/is_wearing_set.md
+++ b/docs/ecoarmor/ecoarmor-effects/conditions/is_wearing_set.md
@@ -2,7 +2,7 @@
 
 Requires a player to be wearing a certain EcoArmor set
 
-:::dangerRequires:
+:::infoRequires:
 EcoArmor
 :::
 

--- a/docs/ecoitems/ecoitems-effects/conditions/has_ecoitem.md
+++ b/docs/ecoitems/ecoitems-effects/conditions/has_ecoitem.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain EcoItem active
 
-:::dangerRequires:
+:::infoRequires:
 EcoItems
 :::
 

--- a/docs/ecojobs/ecojobs-effects/conditions/has_active_job.md
+++ b/docs/ecojobs/ecojobs-effects/conditions/has_active_job.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a job active
 
-:::dangerRequires:
+:::infoRequires:
 EcoJobs
 :::
 

--- a/docs/ecojobs/ecojobs-effects/conditions/has_job_level.md
+++ b/docs/ecojobs/ecojobs-effects/conditions/has_job_level.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain job level
 
-:::dangerRequires:
+:::infoRequires:
 EcoJobs
 :::
 

--- a/docs/ecojobs/ecojobs-effects/effects/give_job_xp.md
+++ b/docs/ecojobs/ecojobs-effects/effects/give_job_xp.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Gives experience points for a certain job
 
-:::dangerRequires:
+:::infoRequires:
 EcoJobs
 :::
 

--- a/docs/ecojobs/ecojobs-effects/effects/job_xp_multiplier.md
+++ b/docs/ecojobs/ecojobs-effects/effects/job_xp_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies job xp gain
 
-:::dangerRequires:
+:::infoRequires:
 EcoJobs
 :::
 

--- a/docs/ecojobs/ecojobs-effects/filters/job.md
+++ b/docs/ecojobs/ecojobs-effects/filters/job.md
@@ -2,7 +2,7 @@
 
 Require a certain job
 
-:::dangerRequires:
+:::infoRequires:
 EcoJobs
 :::
 

--- a/docs/ecopets/ecopets-effects/conditions/has_active_pet.md
+++ b/docs/ecopets/ecopets-effects/conditions/has_active_pet.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a pet active
 
-:::dangerRequires:
+:::infoRequires:
 EcoPets
 :::
 

--- a/docs/ecopets/ecopets-effects/conditions/has_pet.md
+++ b/docs/ecopets/ecopets-effects/conditions/has_pet.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain pet
 
-:::dangerRequires:
+:::infoRequires:
 EcoPets
 :::
 

--- a/docs/ecopets/ecopets-effects/conditions/has_pet_level.md
+++ b/docs/ecopets/ecopets-effects/conditions/has_pet_level.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain pet level
 
-:::dangerRequires:
+:::infoRequires:
 EcoPets
 :::
 

--- a/docs/ecopets/ecopets-effects/effects/give_pet_xp.md
+++ b/docs/ecopets/ecopets-effects/effects/give_pet_xp.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Gives experience points for a certain pet
 
-:::dangerRequires:
+:::infoRequires:
 EcoPets
 :::
 

--- a/docs/ecopets/ecopets-effects/effects/pet_xp_multiplier.md
+++ b/docs/ecopets/ecopets-effects/effects/pet_xp_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies pet xp gain
 
-:::dangerRequires:
+:::infoRequires:
 EcoPets
 :::
 

--- a/docs/ecopets/ecopets-effects/filters/pet.md
+++ b/docs/ecopets/ecopets-effects/filters/pet.md
@@ -2,7 +2,7 @@
 
 Require a certain pet
 
-:::dangerRequires:
+:::infoRequires:
 EcoJobs
 :::
 

--- a/docs/ecoquests/ecoquests-effects/conditions/has_completed_quest.md
+++ b/docs/ecoquests/ecoquests-effects/conditions/has_completed_quest.md
@@ -2,7 +2,7 @@
 
 Requires a player to have completed a quest
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/ecoquests/ecoquests-effects/conditions/has_completed_task.md
+++ b/docs/ecoquests/ecoquests-effects/conditions/has_completed_task.md
@@ -2,7 +2,7 @@
 
 Requires a player to have completed task for a quest
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/ecoquests/ecoquests-effects/conditions/has_quest_active.md
+++ b/docs/ecoquests/ecoquests-effects/conditions/has_quest_active.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a quest active
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/ecoquests/ecoquests-effects/effects/gain_task_xp.md
+++ b/docs/ecoquests/ecoquests-effects/effects/gain_task_xp.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Gains experience points for a task in a quest, including multipliers.
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/ecoquests/ecoquests-effects/effects/give_task_xp.md
+++ b/docs/ecoquests/ecoquests-effects/effects/give_task_xp.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Gives experience points for a task in a quest, excluding multipliers.
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/ecoquests/ecoquests-effects/effects/quest_xp_multiplier.md
+++ b/docs/ecoquests/ecoquests-effects/effects/quest_xp_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies quest xp gain
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/ecoquests/ecoquests-effects/effects/start_quest.md
+++ b/docs/ecoquests/ecoquests-effects/effects/start_quest.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Starts a quest for the player
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/ecoquests/ecoquests-effects/filters/quest.md
+++ b/docs/ecoquests/ecoquests-effects/filters/quest.md
@@ -2,7 +2,7 @@
 
 Require a certain quest
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/ecoquests/ecoquests-effects/filters/task.md
+++ b/docs/ecoquests/ecoquests-effects/filters/task.md
@@ -2,7 +2,7 @@
 
 Require a certain task
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/ecoscrolls/ecoscrolls-effects/conditions/has_scroll.md
+++ b/docs/ecoscrolls/ecoscrolls-effects/conditions/has_scroll.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain scroll active
 
-:::dangerRequires:
+:::infoRequires:
 EcoScrolls
 :::
 

--- a/docs/ecoscrolls/ecoscrolls-effects/effects/inscribe_item.md
+++ b/docs/ecoscrolls/ecoscrolls-effects/effects/inscribe_item.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Inscribes an item with a scroll
 
-:::dangerRequires:
+:::infoRequires:
 EcoScrolls
 :::
 

--- a/docs/ecoscrolls/ecoscrolls-effects/filters/scroll.md
+++ b/docs/ecoscrolls/ecoscrolls-effects/filters/scroll.md
@@ -2,7 +2,7 @@
 
 Require a certain scroll
 
-:::dangerRequires:
+:::infoRequires:
 EcoScrolls
 :::
 

--- a/docs/ecoshop/ecoshop-effects/filters/shop_item.md
+++ b/docs/ecoshop/ecoshop-effects/filters/shop_item.md
@@ -2,7 +2,7 @@
 
 Require a certain shop item
 
-:::dangerRequires:
+:::infoRequires:
 EcoShop
 :::
 

--- a/docs/ecoskills/ecoskills-effects/conditions/above_magic.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/above_magic.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain amount of magic
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/ecoskills/ecoskills-effects/conditions/below_magic.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/below_magic.md
@@ -2,7 +2,7 @@
 
 Requires a player to have less than a certain amount of magic
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/ecoskills/ecoskills-effects/conditions/has_skill_level.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/has_skill_level.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain skill level
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/ecoskills/ecoskills-effects/conditions/stat_above.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/stat_above.md
@@ -2,7 +2,7 @@
 
 Requires a player to have at least a certain stat level
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/ecoskills/ecoskills-effects/conditions/stat_below.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/stat_below.md
@@ -2,7 +2,7 @@
 
 Requires a player to have less than a certain stat level
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/ecoskills/ecoskills-effects/conditions/stat_equals.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/stat_equals.md
@@ -2,7 +2,7 @@
 
 Requires a player to have exactly a certain stat level
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/ecoskills/ecoskills-effects/effects/add_stat_temporarily.md
+++ b/docs/ecoskills/ecoskills-effects/effects/add_stat_temporarily.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Adds a value to a specific stat
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/ecoskills/ecoskills-effects/effects/give_magic.md
+++ b/docs/ecoskills/ecoskills-effects/effects/give_magic.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Add / subtract magic
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/ecoskills/ecoskills-effects/effects/give_skill_xp.md
+++ b/docs/ecoskills/ecoskills-effects/effects/give_skill_xp.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Gives experience points for a certain skill
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/ecoskills/ecoskills-effects/effects/give_skill_xp_naturally.md
+++ b/docs/ecoskills/ecoskills-effects/effects/give_skill_xp_naturally.md
@@ -7,7 +7,7 @@ Gives naturally-gained experience points for a certain skill
 
 This will send a message to a player and will include multipliers.
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/ecoskills/ecoskills-effects/effects/magic_regen_multiplier.md
+++ b/docs/ecoskills/ecoskills-effects/effects/magic_regen_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies magic regeneration
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/ecoskills/ecoskills-effects/effects/make_skill_crit.md
+++ b/docs/ecoskills/ecoskills-effects/effects/make_skill_crit.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Deal a crit hit
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/ecoskills/ecoskills-effects/effects/multiply_all_stats.md
+++ b/docs/ecoskills/ecoskills-effects/effects/multiply_all_stats.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies all stats by a specific value
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/ecoskills/ecoskills-effects/effects/multiply_magic.md
+++ b/docs/ecoskills/ecoskills-effects/effects/multiply_magic.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Multiply magic
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/ecoskills/ecoskills-effects/effects/multiply_stat.md
+++ b/docs/ecoskills/ecoskills-effects/effects/multiply_stat.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies a stat by a specific value
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/ecoskills/ecoskills-effects/effects/multiply_stat_temporarily.md
+++ b/docs/ecoskills/ecoskills-effects/effects/multiply_stat_temporarily.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Multiplies a stat by a specific value
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/ecoskills/ecoskills-effects/filters/magic_type.md
+++ b/docs/ecoskills/ecoskills-effects/filters/magic_type.md
@@ -2,7 +2,7 @@
 
 Require a certain magic type
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/ecoskills/ecoskills-effects/filters/skill.md
+++ b/docs/ecoskills/ecoskills-effects/filters/skill.md
@@ -2,7 +2,7 @@
 
 Require a certain skill
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/effects/all-conditions/above_balance.md
+++ b/docs/effects/all-conditions/above_balance.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain amount of money
 
-:::dangerRequires:
+:::infoRequires:
 Vault
 :::
 

--- a/docs/effects/all-conditions/above_magic.md
+++ b/docs/effects/all-conditions/above_magic.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain amount of magic
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/effects/all-conditions/below_balance.md
+++ b/docs/effects/all-conditions/below_balance.md
@@ -2,7 +2,7 @@
 
 Requires a player to have below a certain amount of money
 
-:::dangerRequires:
+:::infoRequires:
 Vault
 :::
 

--- a/docs/effects/all-conditions/below_magic.md
+++ b/docs/effects/all-conditions/below_magic.md
@@ -2,7 +2,7 @@
 
 Requires a player to have less than a certain amount of magic
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/effects/all-conditions/has_active_job.md
+++ b/docs/effects/all-conditions/has_active_job.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a job active
 
-:::dangerRequires:
+:::infoRequires:
 EcoJobs
 :::
 

--- a/docs/effects/all-conditions/has_active_pet.md
+++ b/docs/effects/all-conditions/has_active_pet.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a pet active
 
-:::dangerRequires:
+:::infoRequires:
 EcoPets
 :::
 

--- a/docs/effects/all-conditions/has_battlepass_tier.md
+++ b/docs/effects/all-conditions/has_battlepass_tier.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain battlepass tier
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Condition Syntax

--- a/docs/effects/all-conditions/has_boss_bar_visible.md
+++ b/docs/effects/all-conditions/has_boss_bar_visible.md
@@ -2,7 +2,7 @@
 
 Requires a player to have the TAB boss bar shown to them
 
-:::dangerRequires:
+:::infoRequires:
 TAB
 :::
 

--- a/docs/effects/all-conditions/has_completed_quest.md
+++ b/docs/effects/all-conditions/has_completed_quest.md
@@ -2,7 +2,7 @@
 
 Requires a player to have completed a quest
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/effects/all-conditions/has_completed_task.md
+++ b/docs/effects/all-conditions/has_completed_task.md
@@ -2,7 +2,7 @@
 
 Requires a player to have completed task for a quest
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/effects/all-conditions/has_ecoitem.md
+++ b/docs/effects/all-conditions/has_ecoitem.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain EcoItem active
 
-:::dangerRequires:
+:::infoRequires:
 EcoItems
 :::
 

--- a/docs/effects/all-conditions/has_job_level.md
+++ b/docs/effects/all-conditions/has_job_level.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain job level
 
-:::dangerRequires:
+:::infoRequires:
 EcoJobs
 :::
 

--- a/docs/effects/all-conditions/has_lands_role.md
+++ b/docs/effects/all-conditions/has_lands_role.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain role in the Land
 
-:::dangerRequires:
+:::infoRequires:
 Lands
 :::
 # Condition Syntax

--- a/docs/effects/all-conditions/has_mana.md
+++ b/docs/effects/all-conditions/has_mana.md
@@ -2,7 +2,7 @@
 
 Requires a player to have amount of mana
 
-:::dangerRequires:
+:::infoRequires:
 AuraSkills
 :::
 

--- a/docs/effects/all-conditions/has_mcmmo_level.md
+++ b/docs/effects/all-conditions/has_mcmmo_level.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain McMMO skill level
 
-:::dangerRequires:
+:::infoRequires:
 McMMO
 :::
 

--- a/docs/effects/all-conditions/has_pet.md
+++ b/docs/effects/all-conditions/has_pet.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain pet
 
-:::dangerRequires:
+:::infoRequires:
 EcoPets
 :::
 

--- a/docs/effects/all-conditions/has_pet_level.md
+++ b/docs/effects/all-conditions/has_pet_level.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain pet level
 
-:::dangerRequires:
+:::infoRequires:
 EcoPets
 :::
 

--- a/docs/effects/all-conditions/has_premium_battlepass.md
+++ b/docs/effects/all-conditions/has_premium_battlepass.md
@@ -2,7 +2,7 @@
 
 Requires a player to have the premium battlepass
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Condition Syntax

--- a/docs/effects/all-conditions/has_quest_active.md
+++ b/docs/effects/all-conditions/has_quest_active.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a quest active
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/effects/all-conditions/has_reforge.md
+++ b/docs/effects/all-conditions/has_reforge.md
@@ -3,7 +3,7 @@
 Requires a player to have a certain reforge active
 
 
-:::dangerRequires:
+:::infoRequires:
 Reforges
 :::
 

--- a/docs/effects/all-conditions/has_scoreboard_visible.md
+++ b/docs/effects/all-conditions/has_scoreboard_visible.md
@@ -2,7 +2,7 @@
 
 Requires a player to have the TAB scoreboard shown to them
 
-:::dangerRequires:
+:::infoRequires:
 TAB
 :::
 

--- a/docs/effects/all-conditions/has_scroll.md
+++ b/docs/effects/all-conditions/has_scroll.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain scroll active
 
-:::dangerRequires:
+:::infoRequires:
 EcoScrolls
 :::
 

--- a/docs/effects/all-conditions/has_skill_level.md
+++ b/docs/effects/all-conditions/has_skill_level.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain skill level
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills / AuraSkills
 :::
 

--- a/docs/effects/all-conditions/has_talisman.md
+++ b/docs/effects/all-conditions/has_talisman.md
@@ -3,7 +3,7 @@
 Requires a player to have a certain talisman active
 
 
-:::dangerRequires:
+:::infoRequires:
 Talismans
 :::
 

--- a/docs/effects/all-conditions/has_town_role.md
+++ b/docs/effects/all-conditions/has_town_role.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain role in a town
 
-:::dangerRequires:
+:::infoRequires:
 HuskTowns
 :::
 # Condition Syntax

--- a/docs/effects/all-conditions/in_bubble.md
+++ b/docs/effects/all-conditions/in_bubble.md
@@ -2,7 +2,7 @@
 
 Requires a player to be in a bubble column
 
-:::dangerRequires:
+:::infoRequires:
 Paper
 :::
 

--- a/docs/effects/all-conditions/in_lava.md
+++ b/docs/effects/all-conditions/in_lava.md
@@ -2,7 +2,7 @@
 
 Requires a player to be in lava
 
-:::dangerRequires:
+:::infoRequires:
 Paper
 :::
 

--- a/docs/effects/all-conditions/in_own_claim.md
+++ b/docs/effects/all-conditions/in_own_claim.md
@@ -2,7 +2,7 @@
 
 Requires the player to be in their own claim
 
-:::dangerRequires:
+:::infoRequires:
 HuskClaims || HuskTowns || Lands
 :::
 # Condition Syntax

--- a/docs/effects/all-conditions/in_rain.md
+++ b/docs/effects/all-conditions/in_rain.md
@@ -2,7 +2,7 @@
 
 Requires a player to be in rain
 
-:::dangerRequires:
+:::infoRequires:
 Paper
 :::
 

--- a/docs/effects/all-conditions/in_region.md
+++ b/docs/effects/all-conditions/in_region.md
@@ -3,7 +3,7 @@
 Requires a player to be in a certain region
 
 
-:::dangerRequires:
+:::infoRequires:
 WorldGuard
 :::
 

--- a/docs/effects/all-conditions/in_trusted_claim.md
+++ b/docs/effects/all-conditions/in_trusted_claim.md
@@ -2,7 +2,7 @@
 
 Requires the player to be in a claim they're trusted in
 
-:::dangerRequires:
+:::infoRequires:
 Lands
 :::
 # Condition Syntax

--- a/docs/effects/all-conditions/is_booster_active.md
+++ b/docs/effects/all-conditions/is_booster_active.md
@@ -2,7 +2,7 @@
 
 Requires a certain booster to be active on the server
 
-:::dangerRequires:
+:::infoRequires:
 Boosters
 :::
 

--- a/docs/effects/all-conditions/is_season.md
+++ b/docs/effects/all-conditions/is_season.md
@@ -2,7 +2,7 @@
 
 Requires it to be a certain season
 
-:::dangerRequires:
+:::infoRequires:
 CustomCrops
 :::
 # Condition Syntax

--- a/docs/effects/all-conditions/is_wearing_set.md
+++ b/docs/effects/all-conditions/is_wearing_set.md
@@ -2,7 +2,7 @@
 
 Requires a player to be wearing a certain EcoArmor set
 
-:::dangerRequires:
+:::infoRequires:
 EcoArmor
 :::
 

--- a/docs/effects/all-conditions/lands_balance_above.md
+++ b/docs/effects/all-conditions/lands_balance_above.md
@@ -2,7 +2,7 @@
 
 Requires the Land's bank balance to be above a value
 
-:::dangerRequires:
+:::infoRequires:
 Lands
 :::
 # Condition Syntax

--- a/docs/effects/all-conditions/lands_balance_below.md
+++ b/docs/effects/all-conditions/lands_balance_below.md
@@ -2,7 +2,7 @@
 
 Requires the Land's bank balance to be below a value
 
-:::dangerRequires:
+:::infoRequires:
 Lands
 :::
 # Condition Syntax

--- a/docs/effects/all-conditions/lands_balance_equal.md
+++ b/docs/effects/all-conditions/lands_balance_equal.md
@@ -2,7 +2,7 @@
 
 Requires the Land's bank balance to be equal to a value
 
-:::dangerRequires:
+:::infoRequires:
 Lands
 :::
 # Condition Syntax

--- a/docs/effects/all-conditions/mcmmo_ability_on_cooldown.md
+++ b/docs/effects/all-conditions/mcmmo_ability_on_cooldown.md
@@ -2,7 +2,7 @@
 
 Requires an McMMO ability to be on cooldown
 
-:::dangerRequires:
+:::infoRequires:
 McMMO
 :::
 

--- a/docs/effects/all-conditions/stat_above.md
+++ b/docs/effects/all-conditions/stat_above.md
@@ -2,7 +2,7 @@
 
 Requires a player to have at least a certain stat level
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/effects/all-conditions/stat_below.md
+++ b/docs/effects/all-conditions/stat_below.md
@@ -2,7 +2,7 @@
 
 Requires a player to have less than a certain stat level
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/effects/all-conditions/stat_equals.md
+++ b/docs/effects/all-conditions/stat_equals.md
@@ -2,7 +2,7 @@
 
 Requires a player to have exactly a certain stat level
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/effects/all-effects/add_durability.md
+++ b/docs/effects/all-effects/add_durability.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Increase the max durability of an item
 
-:::dangerRequires:
+:::infoRequires:
 Server Version 1.21+
 :::
 

--- a/docs/effects/all-effects/add_stat.md
+++ b/docs/effects/all-effects/add_stat.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Adds a value to a specific stat
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills / AuraSkills
 :::
 

--- a/docs/effects/all-effects/add_stat_temporarily.md
+++ b/docs/effects/all-effects/add_stat_temporarily.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Adds a value to a specific stat
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/effects/all-effects/battlepass_task_xp_multiplier.md
+++ b/docs/effects/all-effects/battlepass_task_xp_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies incoming battlepass task xp gain
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Effect Syntax

--- a/docs/effects/all-effects/battlepass_xp_multiplier.md
+++ b/docs/effects/all-effects/battlepass_xp_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies incoming battlepass xp gain
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Effect Syntax

--- a/docs/effects/all-effects/block_reach.md
+++ b/docs/effects/all-effects/block_reach.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Adds reach for interacting with blocks
 
-:::dangerRequires:
+:::infoRequires:
 Server Version 1.21+
 :::
 

--- a/docs/effects/all-effects/burning_time_multiplier.md
+++ b/docs/effects/all-effects/burning_time_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies how long an entity is on fire after being ignited
 
-:::dangerRequires:
+:::infoRequires:
 Server Version 1.21+
 :::
 

--- a/docs/effects/all-effects/drop_pickup_item.md
+++ b/docs/effects/all-effects/drop_pickup_item.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Drops an item that runs a chain on pickup
 
-:::dangerRequires:
+:::infoRequires:
 Paper
 :::
 

--- a/docs/effects/all-effects/entity_reach.md
+++ b/docs/effects/all-effects/entity_reach.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Adds reach for interacting with entities
 
-:::dangerRequires:
+:::infoRequires:
 Server Version 1.21+
 :::
 

--- a/docs/effects/all-effects/explosion_knockback_resistance_multiplier.md
+++ b/docs/effects/all-effects/explosion_knockback_resistance_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies explosion resistance
 
-:::dangerRequires:
+:::infoRequires:
 Server Version 1.21+
 :::
 

--- a/docs/effects/all-effects/gain_task_xp.md
+++ b/docs/effects/all-effects/gain_task_xp.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Gains experience points for a task in a quest, including multipliers.
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/effects/all-effects/give_battlepass_task_xp.md
+++ b/docs/effects/all-effects/give_battlepass_task_xp.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Gives experience points for a task in a quest, excluding multipliers.
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Effect Syntax

--- a/docs/effects/all-effects/give_battlepass_tier.md
+++ b/docs/effects/all-effects/give_battlepass_tier.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Give battlepass tiers to the player.
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Effect Syntax

--- a/docs/effects/all-effects/give_battlepass_xp.md
+++ b/docs/effects/all-effects/give_battlepass_xp.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Give battlepass experience points
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Effect Syntax

--- a/docs/effects/all-effects/give_job_xp.md
+++ b/docs/effects/all-effects/give_job_xp.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Gives experience points for a certain job
 
-:::dangerRequires:
+:::infoRequires:
 EcoJobs
 :::
 

--- a/docs/effects/all-effects/give_lands_balance.md
+++ b/docs/effects/all-effects/give_lands_balance.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Give money to a Land's bank balance
 
-:::dangerRequires:
+:::infoRequires:
 Lands
 :::
 

--- a/docs/effects/all-effects/give_magic.md
+++ b/docs/effects/all-effects/give_magic.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Add / subtract magic
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/effects/all-effects/give_mcmmo_xp.md
+++ b/docs/effects/all-effects/give_mcmmo_xp.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Gives experience points for a certain skill
 
-:::dangerRequires:
+:::infoRequires:
 McMMO
 :::
 

--- a/docs/effects/all-effects/give_money.md
+++ b/docs/effects/all-effects/give_money.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Gives a player money
 
-:::dangerRequires:
+:::infoRequires:
 Vault
 :::
 

--- a/docs/effects/all-effects/give_permission.md
+++ b/docs/effects/all-effects/give_permission.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Gives a permission while active
 
-:::dangerRequires:
+:::infoRequires:
 Vault
 :::
 

--- a/docs/effects/all-effects/give_pet_xp.md
+++ b/docs/effects/all-effects/give_pet_xp.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Gives experience points for a certain pet
 
-:::dangerRequires:
+:::infoRequires:
 EcoPets
 :::
 

--- a/docs/effects/all-effects/give_skill_xp.md
+++ b/docs/effects/all-effects/give_skill_xp.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Gives experience points for a certain skill
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/effects/all-effects/give_skill_xp_naturally.md
+++ b/docs/effects/all-effects/give_skill_xp_naturally.md
@@ -7,7 +7,7 @@ Gives naturally-gained experience points for a certain skill
 
 This will send a message to a player and will include multipliers.
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/effects/all-effects/give_task_xp.md
+++ b/docs/effects/all-effects/give_task_xp.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Gives experience points for a task in a quest, excluding multipliers.
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/effects/all-effects/gravity_multiplier.md
+++ b/docs/effects/all-effects/gravity_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies gravity
 
-:::dangerRequires:
+:::infoRequires:
 Server Version 1.21+
 :::
 

--- a/docs/effects/all-effects/increase_step_height.md
+++ b/docs/effects/all-effects/increase_step_height.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Increases the amount of blocks you can walk over without jumping
 
-:::dangerRequires:
+:::infoRequires:
 Server Version 1.21+
 :::
 

--- a/docs/effects/all-effects/inscribe_item.md
+++ b/docs/effects/all-effects/inscribe_item.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Inscribes an item with a scroll
 
-:::dangerRequires:
+:::infoRequires:
 EcoScrolls
 :::
 

--- a/docs/effects/all-effects/job_xp_multiplier.md
+++ b/docs/effects/all-effects/job_xp_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies job xp gain
 
-:::dangerRequires:
+:::infoRequires:
 EcoJobs
 :::
 

--- a/docs/effects/all-effects/jobs_money_multiplier.md
+++ b/docs/effects/all-effects/jobs_money_multiplier.md
@@ -6,7 +6,7 @@ This effect is permanent and does not require a trigger.
 Multiplies money gain from jobs
 
 
-:::dangerRequires:
+:::infoRequires:
 Jobs Reborn
 :::
 

--- a/docs/effects/all-effects/jobs_xp_multiplier.md
+++ b/docs/effects/all-effects/jobs_xp_multiplier.md
@@ -6,7 +6,7 @@ This effect is permanent and does not require a trigger.
 Multiplies xp gain from jobs
 
 
-:::dangerRequires:
+:::infoRequires:
 Jobs Reborn
 :::
 

--- a/docs/effects/all-effects/jump_strength_multiplier.md
+++ b/docs/effects/all-effects/jump_strength_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies jump strength
 
-:::dangerRequires:
+:::infoRequires:
 Server Version 1.21+
 :::
 

--- a/docs/effects/all-effects/magic_regen_multiplier.md
+++ b/docs/effects/all-effects/magic_regen_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies magic regeneration
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/effects/all-effects/make_skill_crit.md
+++ b/docs/effects/all-effects/make_skill_crit.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Deal a crit hit
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/effects/all-effects/mcmmo_xp_multiplier.md
+++ b/docs/effects/all-effects/mcmmo_xp_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies mcMMO skill xp gain
 
-:::dangerRequires:
+:::infoRequires:
 McMMO
 :::
 

--- a/docs/effects/all-effects/mining_efficiency.md
+++ b/docs/effects/all-effects/mining_efficiency.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Adds mining efficiency (mining speed when using the correct tool)
 
-:::dangerRequires:
+:::infoRequires:
 Server Version 1.21+
 :::
 

--- a/docs/effects/all-effects/mining_speed_multiplier.md
+++ b/docs/effects/all-effects/mining_speed_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies mining speed
 
-:::dangerRequires:
+:::infoRequires:
 Server Version 1.21+
 :::
 

--- a/docs/effects/all-effects/mob_coins_chance_multiplier.md
+++ b/docs/effects/all-effects/mob_coins_chance_multiplier.md
@@ -6,7 +6,7 @@ This effect is permanent and does not require a trigger.
 Multiplies the chance of mobcoins being dropped
 
 
-:::dangerRequires:
+:::infoRequires:
 UltimateMobCoins
 :::
 

--- a/docs/effects/all-effects/mob_coins_drop_multiplier.md
+++ b/docs/effects/all-effects/mob_coins_drop_multiplier.md
@@ -6,7 +6,7 @@ This effect is permanent and does not require a trigger.
 Multiplies the mobcoins dropped
 
 
-:::dangerRequires:
+:::infoRequires:
 UltimateMobCoins
 :::
 

--- a/docs/effects/all-effects/mob_coins_multiplier.md
+++ b/docs/effects/all-effects/mob_coins_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies mob coin drops
 
-:::dangerRequires:
+:::infoRequires:
 Flare Mobcoins
 :::
 

--- a/docs/effects/all-effects/movement_efficiency_multiplier.md
+++ b/docs/effects/all-effects/movement_efficiency_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies movement speed through difficult terrain
 
-:::dangerRequires:
+:::infoRequires:
 Server Version 1.21+
 :::
 

--- a/docs/effects/all-effects/multiply_all_stats.md
+++ b/docs/effects/all-effects/multiply_all_stats.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies all stats by a specific value
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/effects/all-effects/multiply_magic.md
+++ b/docs/effects/all-effects/multiply_magic.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Multiply magic
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/effects/all-effects/multiply_stat.md
+++ b/docs/effects/all-effects/multiply_stat.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies a stat by a specific value
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/effects/all-effects/multiply_stat_temporarily.md
+++ b/docs/effects/all-effects/multiply_stat_temporarily.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Multiplies a stat by a specific value
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/effects/all-effects/pet_xp_multiplier.md
+++ b/docs/effects/all-effects/pet_xp_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies pet xp gain
 
-:::dangerRequires:
+:::infoRequires:
 EcoPets
 :::
 

--- a/docs/effects/all-effects/play_animation.md
+++ b/docs/effects/all-effects/play_animation.md
@@ -6,7 +6,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 Plays a Model Engine animation (The entity must have a custom model active)
 
 
-:::dangerRequires:
+:::infoRequires:
 Model Engine
 :::
 

--- a/docs/effects/all-effects/quest_xp_multiplier.md
+++ b/docs/effects/all-effects/quest_xp_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies quest xp gain
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/effects/all-effects/safe_fall_distance.md
+++ b/docs/effects/all-effects/safe_fall_distance.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Increases/decreases the distance you can fall without taking damage
 
-:::dangerRequires:
+:::infoRequires:
 Server Version 1.21+
 :::
 

--- a/docs/effects/all-effects/scale.md
+++ b/docs/effects/all-effects/scale.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies scale
 
-:::dangerRequires:
+:::infoRequires:
 Server Version 1.21+
 :::
 # Effect Syntax

--- a/docs/effects/all-effects/send_minimessage.md
+++ b/docs/effects/all-effects/send_minimessage.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Sends the player a minimessage message, supports clickable components, etc.
 
-:::dangerRequires:
+:::infoRequires:
 Paper
 :::
 

--- a/docs/effects/all-effects/set_battlepass_tier.md
+++ b/docs/effects/all-effects/set_battlepass_tier.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Set the player's battlepass tier
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Effect Syntax

--- a/docs/effects/all-effects/set_lands_balance.md
+++ b/docs/effects/all-effects/set_lands_balance.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Set the Land bank's balance
 
-:::dangerRequires:
+:::infoRequires:
 Lands
 :::
 

--- a/docs/effects/all-effects/skill_xp_multiplier.md
+++ b/docs/effects/all-effects/skill_xp_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies skill xp gain
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills || AuraSkills
 :::
 

--- a/docs/effects/all-effects/sneaking_speed_multiplier.md
+++ b/docs/effects/all-effects/sneaking_speed_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies sneaking speed
 
-:::dangerRequires:
+:::infoRequires:
 Server Version 1.21+
 :::
 

--- a/docs/effects/all-effects/start_quest.md
+++ b/docs/effects/all-effects/start_quest.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Starts a quest for the player
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/effects/all-effects/take_money.md
+++ b/docs/effects/all-effects/take_money.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Takes money from the player
 
-:::dangerRequires:
+:::infoRequires:
 Vault
 :::
 

--- a/docs/effects/all-effects/underwater_mining_speed_multiplier.md
+++ b/docs/effects/all-effects/underwater_mining_speed_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies underwater mining speed
 
-:::dangerRequires:
+:::infoRequires:
 Server Version 1.21+
 :::
 

--- a/docs/effects/all-effects/water_movement_efficiency_multiplier.md
+++ b/docs/effects/all-effects/water_movement_efficiency_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies water movement efficiency
 
-:::dangerRequires:
+:::infoRequires:
 Server Version 1.21+
 :::
 

--- a/docs/effects/all-filters/at_war_with_victim.md
+++ b/docs/effects/all-filters/at_war_with_victim.md
@@ -2,7 +2,7 @@
 
 Requires the player is in a declared war with the victim
 
-:::dangerRequires:
+:::infoRequires:
 Lands
 :::
 # Filter Syntax

--- a/docs/effects/all-filters/battlepass_reward.md
+++ b/docs/effects/all-filters/battlepass_reward.md
@@ -2,7 +2,7 @@
 
 The list of battlepass rewards the effect should activate on
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Filter Syntax

--- a/docs/effects/all-filters/battlepass_task.md
+++ b/docs/effects/all-filters/battlepass_task.md
@@ -2,7 +2,7 @@
 
 The list of battlepass rewards the effect should activate on
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Filter Syntax

--- a/docs/effects/all-filters/custom_crop_stage.md
+++ b/docs/effects/all-filters/custom_crop_stage.md
@@ -2,7 +2,7 @@
 
 The list of crop stages the effect should activate on
 
-:::dangerRequires:
+:::infoRequires:
 CustomCrops
 :::
 # Filter Syntax

--- a/docs/effects/all-filters/custom_crop_type.md
+++ b/docs/effects/all-filters/custom_crop_type.md
@@ -2,7 +2,7 @@
 
 The list of crop types the effect should activate on
 
-:::dangerRequires:
+:::infoRequires:
 CustomCrops
 :::
 # Filter Syntax

--- a/docs/effects/all-filters/custom_fish_type.md
+++ b/docs/effects/all-filters/custom_fish_type.md
@@ -2,7 +2,7 @@
 
 The list of fish types the effect should activate on
 
-:::dangerRequires:
+:::infoRequires:
 CustomFishing
 :::
 # Filter Syntax

--- a/docs/effects/all-filters/envoy_type.md
+++ b/docs/effects/all-filters/envoy_type.md
@@ -2,7 +2,7 @@
 
 The list of envoy types that the effect should activate against
 
-:::dangerRequires:
+:::infoRequires:
 AxEnvoy
 :::
 

--- a/docs/effects/all-filters/fertilizer_type.md
+++ b/docs/effects/all-filters/fertilizer_type.md
@@ -2,7 +2,7 @@
 
 The list of fertilizers the effect should activate on
 
-:::dangerRequires:
+:::infoRequires:
 CustomCrops
 :::
 # Filter Syntax

--- a/docs/effects/all-filters/job.md
+++ b/docs/effects/all-filters/job.md
@@ -2,7 +2,7 @@
 
 Require a certain job
 
-:::dangerRequires:
+:::infoRequires:
 EcoJobs
 :::
 

--- a/docs/effects/all-filters/magic_type.md
+++ b/docs/effects/all-filters/magic_type.md
@@ -2,7 +2,7 @@
 
 Require a certain magic type
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills
 :::
 

--- a/docs/effects/all-filters/npc.md
+++ b/docs/effects/all-filters/npc.md
@@ -2,7 +2,7 @@
 
 Require a certain NPC
 
-:::dangerRequires:
+:::infoRequires:
 Citizens || FancyNpcs
 :::
 

--- a/docs/effects/all-filters/pet.md
+++ b/docs/effects/all-filters/pet.md
@@ -2,7 +2,7 @@
 
 Require a certain pet
 
-:::dangerRequires:
+:::infoRequires:
 EcoPets
 :::
 

--- a/docs/effects/all-filters/quest.md
+++ b/docs/effects/all-filters/quest.md
@@ -2,7 +2,7 @@
 
 Require a certain quest
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/effects/all-filters/region.md
+++ b/docs/effects/all-filters/region.md
@@ -3,7 +3,7 @@
 Require a certain region
 
 
-:::dangerRequires:
+:::infoRequires:
 WorldGuard
 :::
 

--- a/docs/effects/all-filters/scroll.md
+++ b/docs/effects/all-filters/scroll.md
@@ -2,7 +2,7 @@
 
 Require a certain scroll
 
-:::dangerRequires:
+:::infoRequires:
 EcoScrolls
 :::
 

--- a/docs/effects/all-filters/shop_item.md
+++ b/docs/effects/all-filters/shop_item.md
@@ -2,7 +2,7 @@
 
 Require a certain shop item
 
-:::dangerRequires:
+:::infoRequires:
 EcoShop
 :::
 

--- a/docs/effects/all-filters/skill.md
+++ b/docs/effects/all-filters/skill.md
@@ -2,7 +2,7 @@
 
 Require a certain skill
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills || McMMO
 :::
 

--- a/docs/effects/all-filters/task.md
+++ b/docs/effects/all-filters/task.md
@@ -2,7 +2,7 @@
 
 Require a certain task
 
-:::dangerRequires:
+:::infoRequires:
 EcoQuests
 :::
 

--- a/docs/effects/all-filters/town_role.md
+++ b/docs/effects/all-filters/town_role.md
@@ -2,7 +2,7 @@
 
 The list of town roles the effect should activate on
 
-:::dangerRequires:
+:::infoRequires:
 HuskTowns
 :::
 # Filter Syntax

--- a/docs/effects/all-filters/vote_service.md
+++ b/docs/effects/all-filters/vote_service.md
@@ -3,7 +3,7 @@
 The list of vote services that the effect should activate on
 
 
-:::dangerRequires:
+:::infoRequires:
 Votifier
 :::
 

--- a/docs/effects/all-filters/watering_can_type.md
+++ b/docs/effects/all-filters/watering_can_type.md
@@ -2,7 +2,7 @@
 
 The list of watering cans the effect should activate on
 
-:::dangerRequires:
+:::infoRequires:
 CustomCrops
 :::
 # Filter Syntax

--- a/docs/effects/all-triggers.md
+++ b/docs/effects/all-triggers.md
@@ -8,7 +8,7 @@ Triggered effects require a trigger, permanent effects do not support triggers a
 Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders), and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
 
 | ID                              | Description                                                                                                       | Value                                         | Alt-Value       |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | --------------- |
+| ------------------------------- |-------------------------------------------------------------------------------------------------------------------| --------------------------------------------- | --------------- |
 | `alt_click`                     | Triggered when using Right Click on most items, Left Click on those that have a default right click functionality | 1                                             | -               |
 | `beacon_effect`                 | Triggered when a player gains effects from a beacon **Requires Paper**                                            | 1                                             | -               |
 | `bite`                          | Triggered when a fish bites on your rod                                                                           | 1                                             | -               |
@@ -31,9 +31,7 @@ Triggered effects also produce a value, and some product an alt-value, which can
 | `claim_battlepass_reward`       | Triggered when claiming a battlepass reward **Requires xBattlepass**                                              | 1                                             | -               |
 | `click_block`                   | Triggered when right-clicking on a block                                                                          | 1                                             | -               |
 | `click_entity`                  | Triggered when right-clicking on an entity                                                                        | 1                                             | -               |
-| `collect_envoy`                 | Triggered when collecting an envoy crate :::dangerRequires:
-AxEnvoy
-:::                                                     | 1                                             | -               |
+| `collect_envoy`                 | Triggered when collecting an envoy crate **Requires AxEnvoy**                                                     | 1                                             | -               |
 | `complete_advancement`          | Triggered when completing an advancement                                                                          | 1                                             | -               |
 | `complete_battlepass_task`      | Triggered when completing a battlepass task **Requires xBattlepass**                                              | 1                                             | -               |
 | `complete_quest`                | Triggered when completing a quest **Requires EcoQuests**                                                          | 1                                             | -               |

--- a/docs/effects/external-integrations/auraskills/conditions/has_mana.md
+++ b/docs/effects/external-integrations/auraskills/conditions/has_mana.md
@@ -2,7 +2,7 @@
 
 Requires a player to have amount of mana
 
-:::dangerRequires:
+:::infoRequires:
 AuraSkills
 :::
 

--- a/docs/effects/external-integrations/auraskills/conditions/has_skill_level.md
+++ b/docs/effects/external-integrations/auraskills/conditions/has_skill_level.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain skill level
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills || AuraSkills
 :::
 

--- a/docs/effects/external-integrations/auraskills/effects/skill_xp_multiplier.md
+++ b/docs/effects/external-integrations/auraskills/effects/skill_xp_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies skill xp gain
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills || AuraSkills
 :::
 

--- a/docs/effects/external-integrations/axenvoy/filters/envoy_type.md
+++ b/docs/effects/external-integrations/axenvoy/filters/envoy_type.md
@@ -2,7 +2,7 @@
 
 The list of envoy types that the effect should activate against
 
-:::dangerRequires:
+:::infoRequires:
 AxEnvoy
 :::
 

--- a/docs/effects/external-integrations/citizens/filters/npc.md
+++ b/docs/effects/external-integrations/citizens/filters/npc.md
@@ -2,7 +2,7 @@
 
 Require a certain NPC
 
-:::dangerRequires:
+:::infoRequires:
 Citizens || FancyNpcs
 :::
 

--- a/docs/effects/external-integrations/customcrops/conditions/is_season.md
+++ b/docs/effects/external-integrations/customcrops/conditions/is_season.md
@@ -2,7 +2,7 @@
 
 Requires it to be a certain season
 
-:::dangerRequires:
+:::infoRequires:
 CustomCrops
 :::
 # Example Config

--- a/docs/effects/external-integrations/customcrops/filters/custom_crop_stage.md
+++ b/docs/effects/external-integrations/customcrops/filters/custom_crop_stage.md
@@ -2,7 +2,7 @@
 
 The list of crop stages the effect should activate on
 
-:::dangerRequires:
+:::infoRequires:
 CustomCrops
 :::
 # Example Config

--- a/docs/effects/external-integrations/customcrops/filters/custom_crop_type.md
+++ b/docs/effects/external-integrations/customcrops/filters/custom_crop_type.md
@@ -2,7 +2,7 @@
 
 The list of crop types the effect should activate on
 
-:::dangerRequires:
+:::infoRequires:
 CustomCrops
 :::
 # Example Config

--- a/docs/effects/external-integrations/customcrops/filters/fertilizer_type.md
+++ b/docs/effects/external-integrations/customcrops/filters/fertilizer_type.md
@@ -2,7 +2,7 @@
 
 The list of fertilizers the effect should activate on
 
-:::dangerRequires:
+:::infoRequires:
 CustomCrops
 :::
 # Example Config

--- a/docs/effects/external-integrations/customcrops/filters/watering_can_type.md
+++ b/docs/effects/external-integrations/customcrops/filters/watering_can_type.md
@@ -2,7 +2,7 @@
 
 The list of watering cans the effect should activate on
 
-:::dangerRequires:
+:::infoRequires:
 CustomCrops
 :::
 # Example Config

--- a/docs/effects/external-integrations/customfishing/filters/custom_fish_type.md
+++ b/docs/effects/external-integrations/customfishing/filters/custom_fish_type.md
@@ -2,7 +2,7 @@
 
 The list of fish types the effect should activate on
 
-:::dangerRequires:
+:::infoRequires:
 CustomFishing
 :::
 # Example Config

--- a/docs/effects/external-integrations/fancynpcs/filters/npc.md
+++ b/docs/effects/external-integrations/fancynpcs/filters/npc.md
@@ -2,7 +2,7 @@
 
 Require a certain NPC
 
-:::dangerRequires:
+:::infoRequires:
 Citizens || FancyNpcs
 :::
 

--- a/docs/effects/external-integrations/flaremobcoins/effects/mob_coins_multiplier.md
+++ b/docs/effects/external-integrations/flaremobcoins/effects/mob_coins_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies mob coin drops
 
-:::dangerRequires:
+:::infoRequires:
 Flare Mobcoins
 :::
 

--- a/docs/effects/external-integrations/huskclaims/conditions/in_own_claim.md
+++ b/docs/effects/external-integrations/huskclaims/conditions/in_own_claim.md
@@ -2,7 +2,7 @@
 
 Requires the player to be in their own claim
 
-:::dangerRequires:
+:::infoRequires:
 HuskClaims || HuskTowns || Lands
 :::
 # Example Config

--- a/docs/effects/external-integrations/husktowns/conditions/has_town_role.md
+++ b/docs/effects/external-integrations/husktowns/conditions/has_town_role.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain role in a town
 
-:::dangerRequires:
+:::infoRequires:
 HuskTowns
 :::
 # Example Config

--- a/docs/effects/external-integrations/husktowns/conditions/in_own_claim.md
+++ b/docs/effects/external-integrations/husktowns/conditions/in_own_claim.md
@@ -2,7 +2,7 @@
 
 Requires the player to be in their own claim
 
-:::dangerRequires:
+:::infoRequires:
 HuskClaims || HuskTowns || Lands
 :::
 # Example Config

--- a/docs/effects/external-integrations/husktowns/filters/town_role.md
+++ b/docs/effects/external-integrations/husktowns/filters/town_role.md
@@ -2,7 +2,7 @@
 
 The list of town roles the effect should activate on
 
-:::dangerRequires:
+:::infoRequires:
 HuskTowns
 :::
 # Example Config

--- a/docs/effects/external-integrations/jobs-reborn/effects/jobs_money_multiplier.md
+++ b/docs/effects/external-integrations/jobs-reborn/effects/jobs_money_multiplier.md
@@ -6,7 +6,7 @@ This effect is permanent and does not require a trigger.
 Multiplies money gain from jobs
 
 
-:::dangerRequires:
+:::infoRequires:
 Jobs Reborn
 :::
 

--- a/docs/effects/external-integrations/jobs-reborn/effects/jobs_xp_multiplier.md
+++ b/docs/effects/external-integrations/jobs-reborn/effects/jobs_xp_multiplier.md
@@ -6,7 +6,7 @@ This effect is permanent and does not require a trigger.
 Multiplies xp gain from jobs
 
 
-:::dangerRequires:
+:::infoRequires:
 Jobs Reborn
 :::
 

--- a/docs/effects/external-integrations/lands/conditions/has_lands_role.md
+++ b/docs/effects/external-integrations/lands/conditions/has_lands_role.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain role in the Land
 
-:::dangerRequires:
+:::infoRequires:
 Lands
 :::
 # Example Config

--- a/docs/effects/external-integrations/lands/conditions/in_own_claim.md
+++ b/docs/effects/external-integrations/lands/conditions/in_own_claim.md
@@ -2,7 +2,7 @@
 
 Requires the player to be in their own claim
 
-:::dangerRequires:
+:::infoRequires:
 HuskClaims || HuskTowns || Lands
 :::
 # Example Config

--- a/docs/effects/external-integrations/lands/conditions/in_trusted_claim.md
+++ b/docs/effects/external-integrations/lands/conditions/in_trusted_claim.md
@@ -2,7 +2,7 @@
 
 Requires the player to be in a claim they're trusted in
 
-:::dangerRequires:
+:::infoRequires:
 Lands
 :::
 # Example Config

--- a/docs/effects/external-integrations/lands/conditions/lands_balance_above.md
+++ b/docs/effects/external-integrations/lands/conditions/lands_balance_above.md
@@ -2,7 +2,7 @@
 
 Requires the Land's bank balance to be above a value
 
-:::dangerRequires:
+:::infoRequires:
 Lands
 :::
 # Example Config

--- a/docs/effects/external-integrations/lands/conditions/lands_balance_below.md
+++ b/docs/effects/external-integrations/lands/conditions/lands_balance_below.md
@@ -2,7 +2,7 @@
 
 Requires the Land's bank balance to be below a value
 
-:::dangerRequires:
+:::infoRequires:
 Lands
 :::
 # Example Config

--- a/docs/effects/external-integrations/lands/conditions/lands_balance_equal.md
+++ b/docs/effects/external-integrations/lands/conditions/lands_balance_equal.md
@@ -2,7 +2,7 @@
 
 Requires the Land's bank balance to be equal to a value
 
-:::dangerRequires:
+:::infoRequires:
 Lands
 :::
 # Example Config

--- a/docs/effects/external-integrations/lands/effects/give_lands_balance.md
+++ b/docs/effects/external-integrations/lands/effects/give_lands_balance.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Give money to a Land's bank balance
 
-:::dangerRequires:
+:::infoRequires:
 Lands
 :::
 

--- a/docs/effects/external-integrations/lands/effects/set_lands_balance.md
+++ b/docs/effects/external-integrations/lands/effects/set_lands_balance.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Set the Land bank's balance
 
-:::dangerRequires:
+:::infoRequires:
 Lands
 :::
 

--- a/docs/effects/external-integrations/lands/filters/at_war_with_victim.md
+++ b/docs/effects/external-integrations/lands/filters/at_war_with_victim.md
@@ -2,7 +2,7 @@
 
 Requires the player is in a declared war with the victim
 
-:::dangerRequires:
+:::infoRequires:
 Lands
 :::
 # Example Config

--- a/docs/effects/external-integrations/mcmmo/conditions/has_mcmmo_level.md
+++ b/docs/effects/external-integrations/mcmmo/conditions/has_mcmmo_level.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain McMMO skill level
 
-:::dangerRequires:
+:::infoRequires:
 McMMO
 :::
 

--- a/docs/effects/external-integrations/mcmmo/conditions/mcmmo_ability_on_cooldown.md
+++ b/docs/effects/external-integrations/mcmmo/conditions/mcmmo_ability_on_cooldown.md
@@ -2,7 +2,7 @@
 
 Requires an McMMO ability to be on cooldown
 
-:::dangerRequires:
+:::infoRequires:
 McMMO
 :::
 

--- a/docs/effects/external-integrations/mcmmo/effects/give_mcmmo_xp.md
+++ b/docs/effects/external-integrations/mcmmo/effects/give_mcmmo_xp.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Gives experience points for a certain skill
 
-:::dangerRequires:
+:::infoRequires:
 McMMO
 :::
 

--- a/docs/effects/external-integrations/mcmmo/effects/mcmmo_xp_multiplier.md
+++ b/docs/effects/external-integrations/mcmmo/effects/mcmmo_xp_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies mcMMO skill xp gain
 
-:::dangerRequires:
+:::infoRequires:
 McMMO
 :::
 

--- a/docs/effects/external-integrations/mcmmo/filters/mcmmo_ability.md
+++ b/docs/effects/external-integrations/mcmmo/filters/mcmmo_ability.md
@@ -2,7 +2,7 @@
 
 The list of [entities](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html) that the effect should activate against
 
-:::dangerRequires:
+:::infoRequires:
 Lands
 :::
 

--- a/docs/effects/external-integrations/mcmmo/filters/skill.md
+++ b/docs/effects/external-integrations/mcmmo/filters/skill.md
@@ -2,7 +2,7 @@
 
 Require a certain skill
 
-:::dangerRequires:
+:::infoRequires:
 EcoSkills || McMMO
 :::
 

--- a/docs/effects/external-integrations/modelengine/effects/play_animation.md
+++ b/docs/effects/external-integrations/modelengine/effects/play_animation.md
@@ -6,7 +6,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 Plays a Model Engine animation (The entity must have a custom model active)
 
 
-:::dangerRequires:
+:::infoRequires:
 Model Engine
 :::
 

--- a/docs/effects/external-integrations/paper/conditions/in_bubble.md
+++ b/docs/effects/external-integrations/paper/conditions/in_bubble.md
@@ -2,7 +2,7 @@
 
 Requires a player to be in a bubble column
 
-:::dangerRequires:
+:::infoRequires:
 Paper
 :::
 

--- a/docs/effects/external-integrations/paper/conditions/in_lava.md
+++ b/docs/effects/external-integrations/paper/conditions/in_lava.md
@@ -2,7 +2,7 @@
 
 Requires a player to be in lava
 
-:::dangerRequires:
+:::infoRequires:
 Paper
 :::
 

--- a/docs/effects/external-integrations/paper/conditions/in_rain.md
+++ b/docs/effects/external-integrations/paper/conditions/in_rain.md
@@ -2,7 +2,7 @@
 
 Requires a player to be in rain
 
-:::dangerRequires:
+:::infoRequires:
 Paper
 :::
 

--- a/docs/effects/external-integrations/paper/effects/drop_pickup_item.md
+++ b/docs/effects/external-integrations/paper/effects/drop_pickup_item.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Drops an item that runs a chain on pickup
 
-:::dangerRequires:
+:::infoRequires:
 Paper
 :::
 

--- a/docs/effects/external-integrations/paper/effects/send_minimessage.md
+++ b/docs/effects/external-integrations/paper/effects/send_minimessage.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Sends the player a minimessage message, supports clickable components, etc.
 
-:::dangerRequires:
+:::infoRequires:
 Paper
 :::
 

--- a/docs/effects/external-integrations/tab/conditions/has_boss_bar_visible.md
+++ b/docs/effects/external-integrations/tab/conditions/has_boss_bar_visible.md
@@ -2,7 +2,7 @@
 
 Requires a player to have the TAB boss bar shown to them
 
-:::dangerRequires:
+:::infoRequires:
 TAB
 :::
 

--- a/docs/effects/external-integrations/tab/conditions/has_scoreboard_visible.md
+++ b/docs/effects/external-integrations/tab/conditions/has_scoreboard_visible.md
@@ -2,7 +2,7 @@
 
 Requires a player to have the TAB scoreboard shown to them
 
-:::dangerRequires:
+:::infoRequires:
 TAB
 :::
 

--- a/docs/effects/external-integrations/ultimatemobcoins/effects/mob_coins_chance_multiplier.md
+++ b/docs/effects/external-integrations/ultimatemobcoins/effects/mob_coins_chance_multiplier.md
@@ -6,7 +6,7 @@ This effect is permanent and does not require a trigger.
 Multiplies the chance of mobcoins being dropped
 
 
-:::dangerRequires:
+:::infoRequires:
 UltimateMobCoins
 :::
 

--- a/docs/effects/external-integrations/ultimatemobcoins/effects/mob_coins_drop_multiplier.md
+++ b/docs/effects/external-integrations/ultimatemobcoins/effects/mob_coins_drop_multiplier.md
@@ -6,7 +6,7 @@ This effect is permanent and does not require a trigger.
 Multiplies the mobcoins dropped
 
 
-:::dangerRequires:
+:::infoRequires:
 UltimateMobCoins
 :::
 

--- a/docs/effects/external-integrations/vault/effects/give_permission.md
+++ b/docs/effects/external-integrations/vault/effects/give_permission.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Gives a permission while active
 
-:::dangerRequires:
+:::infoRequires:
 Vault
 :::
 

--- a/docs/effects/external-integrations/votifier/filters/vote_service.md
+++ b/docs/effects/external-integrations/votifier/filters/vote_service.md
@@ -3,7 +3,7 @@
 The list of vote services that the effect should activate on
 
 
-:::dangerRequires:
+:::infoRequires:
 Votifier
 :::
 

--- a/docs/effects/external-integrations/worldguard/conditions/in_region.md
+++ b/docs/effects/external-integrations/worldguard/conditions/in_region.md
@@ -3,7 +3,7 @@
 Requires a player to be in a certain region
 
 
-:::dangerRequires:
+:::infoRequires:
 WorldGuard
 :::
 

--- a/docs/effects/external-integrations/worldguard/filters/region.md
+++ b/docs/effects/external-integrations/worldguard/filters/region.md
@@ -3,7 +3,7 @@
 Require a certain region
 
 
-:::dangerRequires:
+:::infoRequires:
 WorldGuard
 :::
 

--- a/docs/effects/external-integrations/xbattlepass/conditions/has_battlepass_tier.md
+++ b/docs/effects/external-integrations/xbattlepass/conditions/has_battlepass_tier.md
@@ -2,7 +2,7 @@
 
 Requires a player to have a certain battlepass tier
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Example Config

--- a/docs/effects/external-integrations/xbattlepass/conditions/has_premium_battlepass.md
+++ b/docs/effects/external-integrations/xbattlepass/conditions/has_premium_battlepass.md
@@ -2,7 +2,7 @@
 
 Requires a player to have the premium battlepass
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Example Config

--- a/docs/effects/external-integrations/xbattlepass/effects/battlepass_task_xp_multiplier.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/battlepass_task_xp_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies incoming battlepass task xp gain
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Example Config

--- a/docs/effects/external-integrations/xbattlepass/effects/battlepass_xp_multiplier.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/battlepass_xp_multiplier.md
@@ -5,7 +5,7 @@ This effect is permanent and does not require a trigger.
 
 Multiplies incoming battlepass xp gain
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Example Config

--- a/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_task_xp.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_task_xp.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Gives experience points for a task in a quest, excluding multipliers.
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Example Config

--- a/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_tier.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_tier.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Give battlepass tiers to the player.
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Example Config

--- a/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_xp.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_xp.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Give battlepass experience points
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Example Config

--- a/docs/effects/external-integrations/xbattlepass/effects/set_battlepass_tier.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/set_battlepass_tier.md
@@ -5,7 +5,7 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 
 Set the player's battlepass tier
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Example Config

--- a/docs/effects/external-integrations/xbattlepass/filters/battlepass_reward.md
+++ b/docs/effects/external-integrations/xbattlepass/filters/battlepass_reward.md
@@ -2,7 +2,7 @@
 
 The list of battlepass rewards the effect should activate on
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Example Config

--- a/docs/effects/external-integrations/xbattlepass/filters/battlepass_task.md
+++ b/docs/effects/external-integrations/xbattlepass/filters/battlepass_task.md
@@ -2,7 +2,7 @@
 
 The list of battlepass rewards the effect should activate on
 
-:::dangerRequires:
+:::infoRequires:
 xBattlepass
 :::
 # Example Config

--- a/docs/reforges/reforges-effects/conditions/has_reforge.md
+++ b/docs/reforges/reforges-effects/conditions/has_reforge.md
@@ -3,7 +3,7 @@
 Requires a player to have a certain reforge active
 
 
-:::dangerRequires:
+:::infoRequires:
 Reforges
 :::
 

--- a/docs/talismans/talismans-effects/conditions/has_talisman.md
+++ b/docs/talismans/talismans-effects/conditions/has_talisman.md
@@ -3,7 +3,7 @@
 Requires a player to have a certain talisman active
 
 
-:::dangerRequires:
+:::infoRequires:
 Talismans
 :::
 


### PR DESCRIPTION
Replaces all instances of the ':::dangerRequires:' admonition with ':::infoRequires:' across multiple documentation files for consistency and improved clarity.