### PR TITLE
Refactor plugin docs: move 'Requires' info above descriptions

### DIFF
--- a/docs/all-plugins/custom-entity-ai/all-entity-goals/ecomobs_random_teleport.md
+++ b/docs/all-plugins/custom-entity-ai/all-entity-goals/ecomobs_random_teleport.md
@@ -1,10 +1,9 @@
 # `ecomobs:random_teleport`
-
-Allows a mob to teleport around randomly
-
 :::infoRequires:
 EcoMobs
 :::
+
+Allows a mob to teleport around randomly
 # Example Config
 ```yaml
 - key: ecomobs:random_teleport

--- a/docs/boosters/boosters-effects/conditions/is_booster_active.md
+++ b/docs/boosters/boosters-effects/conditions/is_booster_active.md
@@ -1,10 +1,9 @@
 # `is_booster_active`
-
-Requires a certain booster to be active on the server
-
 :::infoRequires:
 Boosters
 :::
+
+Requires a certain booster to be active on the server
 # Condition Syntax
 ```yaml
 - id: is_booster_active

--- a/docs/ecoarmor/ecoarmor-effects/conditions/is_wearing_set.md
+++ b/docs/ecoarmor/ecoarmor-effects/conditions/is_wearing_set.md
@@ -1,10 +1,9 @@
 # `is_wearing_set`
-
-Requires a player to be wearing a certain EcoArmor set
-
 :::infoRequires:
 EcoArmor
 :::
+
+Requires a player to be wearing a certain EcoArmor set
 # Condition Syntax
 ```yaml
 - id: is_wearing_set

--- a/docs/ecoitems/ecoitems-effects/conditions/has_ecoitem.md
+++ b/docs/ecoitems/ecoitems-effects/conditions/has_ecoitem.md
@@ -1,10 +1,9 @@
 # `has_ecoitem`
-
-Requires a player to have a certain EcoItem active
-
 :::infoRequires:
 EcoItems
 :::
+
+Requires a player to have a certain EcoItem active
 # Condition Syntax
 ```yaml
 - id: has_ecoitem

--- a/docs/ecojobs/ecojobs-effects/conditions/has_active_job.md
+++ b/docs/ecojobs/ecojobs-effects/conditions/has_active_job.md
@@ -1,10 +1,9 @@
 # `has_active_job`
-
-Requires a player to have a job active
-
 :::infoRequires:
 EcoJobs
 :::
+
+Requires a player to have a job active
 # Condition Syntax
 ```yaml
 - id: has_active_job

--- a/docs/ecojobs/ecojobs-effects/conditions/has_job_level.md
+++ b/docs/ecojobs/ecojobs-effects/conditions/has_job_level.md
@@ -1,10 +1,9 @@
 # `has_job_level`
-
-Requires a player to have a certain job level
-
 :::infoRequires:
 EcoJobs
 :::
+
+Requires a player to have a certain job level
 # Condition Syntax
 ```yaml
 - id: has_job_level

--- a/docs/ecojobs/ecojobs-effects/effects/give_job_xp.md
+++ b/docs/ecojobs/ecojobs-effects/effects/give_job_xp.md
@@ -1,13 +1,13 @@
 # `give_job_xp`
+:::infoRequires:
+EcoJobs
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a certain job
-
-:::infoRequires:
-EcoJobs
-:::
 # Effect Syntax
 ```yaml
 - id: give_job_xp

--- a/docs/ecojobs/ecojobs-effects/effects/job_xp_multiplier.md
+++ b/docs/ecojobs/ecojobs-effects/effects/job_xp_multiplier.md
@@ -1,13 +1,13 @@
 # `job_xp_multiplier`
+:::infoRequires:
+EcoJobs
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies job xp gain
-
-:::infoRequires:
-EcoJobs
-:::
 # Effect Syntax
 ```yaml
 - id: job_xp_multiplier

--- a/docs/ecojobs/ecojobs-effects/filters/job.md
+++ b/docs/ecojobs/ecojobs-effects/filters/job.md
@@ -1,10 +1,9 @@
 # `job`
-
-Require a certain job
-
 :::infoRequires:
 EcoJobs
 :::
+
+Require a certain job
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/ecopets/ecopets-effects/conditions/has_active_pet.md
+++ b/docs/ecopets/ecopets-effects/conditions/has_active_pet.md
@@ -1,10 +1,9 @@
 # `has_active_pet`
-
-Requires a player to have a pet active
-
 :::infoRequires:
 EcoPets
 :::
+
+Requires a player to have a pet active
 # Condition Syntax
 ```yaml
 - id: has_active_pet

--- a/docs/ecopets/ecopets-effects/conditions/has_pet.md
+++ b/docs/ecopets/ecopets-effects/conditions/has_pet.md
@@ -1,10 +1,9 @@
 # `has_pet
-
-Requires a player to have a certain pet
-
 :::infoRequires:
 EcoPets
 :::
+
+Requires a player to have a certain pet
 # Condition Syntax
 ```yaml
 - id: has_pet

--- a/docs/ecopets/ecopets-effects/conditions/has_pet_level.md
+++ b/docs/ecopets/ecopets-effects/conditions/has_pet_level.md
@@ -1,10 +1,9 @@
 # `has_pet_level`
-
-Requires a player to have a certain pet level
-
 :::infoRequires:
 EcoPets
 :::
+
+Requires a player to have a certain pet level
 # Condition Syntax
 ```yaml
 - id: has_pet_level

--- a/docs/ecopets/ecopets-effects/effects/give_pet_xp.md
+++ b/docs/ecopets/ecopets-effects/effects/give_pet_xp.md
@@ -1,13 +1,13 @@
 # `give_pet_xp`
+:::infoRequires:
+EcoPets
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a certain pet
-
-:::infoRequires:
-EcoPets
-:::
 # Effect Syntax
 ```yaml
 - id: give_pet_xp

--- a/docs/ecopets/ecopets-effects/effects/pet_xp_multiplier.md
+++ b/docs/ecopets/ecopets-effects/effects/pet_xp_multiplier.md
@@ -1,13 +1,13 @@
 # `pet_xp_multiplier`
+:::infoRequires:
+EcoPets
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies pet xp gain
-
-:::infoRequires:
-EcoPets
-:::
 # Effect Syntax
 ```yaml
 - id: pet_xp_multiplier

--- a/docs/ecopets/ecopets-effects/filters/pet.md
+++ b/docs/ecopets/ecopets-effects/filters/pet.md
@@ -1,10 +1,9 @@
 # `pet`
-
-Require a certain pet
-
 :::infoRequires:
 EcoPets
 :::
+
+Require a certain pet
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/ecoquests/ecoquests-effects/conditions/has_completed_quest.md
+++ b/docs/ecoquests/ecoquests-effects/conditions/has_completed_quest.md
@@ -1,10 +1,9 @@
 # `has_completed_quest`
-
-Requires a player to have completed a quest
-
 :::infoRequires:
 EcoQuests
 :::
+
+Requires a player to have completed a quest
 # Condition Syntax
 ```yaml
 - id: has_completed_quest

--- a/docs/ecoquests/ecoquests-effects/conditions/has_completed_task.md
+++ b/docs/ecoquests/ecoquests-effects/conditions/has_completed_task.md
@@ -1,10 +1,9 @@
 # `has_completed_task`
-
-Requires a player to have completed task for a quest
-
 :::infoRequires:
 EcoQuests
 :::
+
+Requires a player to have completed task for a quest
 # Condition Syntax
 ```yaml
 - id: has_completed_task

--- a/docs/ecoquests/ecoquests-effects/conditions/has_quest_active.md
+++ b/docs/ecoquests/ecoquests-effects/conditions/has_quest_active.md
@@ -1,10 +1,9 @@
 # `has_quest_active`
-
-Requires a player to have a quest active
-
 :::infoRequires:
 EcoQuests
 :::
+
+Requires a player to have a quest active
 # Condition Syntax
 ```yaml
 - id: has_quest_active

--- a/docs/ecoquests/ecoquests-effects/effects/gain_task_xp.md
+++ b/docs/ecoquests/ecoquests-effects/effects/gain_task_xp.md
@@ -1,13 +1,13 @@
 # `gain_task_xp`
+:::infoRequires:
+EcoQuests
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gains experience points for a task in a quest, including multipliers.
-
-:::infoRequires:
-EcoQuests
-:::
 # Effect Syntax
 ```yaml
 - id: gain_task_xp

--- a/docs/ecoquests/ecoquests-effects/effects/give_task_xp.md
+++ b/docs/ecoquests/ecoquests-effects/effects/give_task_xp.md
@@ -1,13 +1,13 @@
 # `give_task_xp`
+:::infoRequires:
+EcoQuests
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a task in a quest, excluding multipliers.
-
-:::infoRequires:
-EcoQuests
-:::
 # Effect Syntax
 ```yaml
 - id: give_task_xp

--- a/docs/ecoquests/ecoquests-effects/effects/quest_xp_multiplier.md
+++ b/docs/ecoquests/ecoquests-effects/effects/quest_xp_multiplier.md
@@ -1,13 +1,13 @@
 # `quest_xp_multiplier`
+:::infoRequires:
+EcoQuests
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies quest xp gain
-
-:::infoRequires:
-EcoQuests
-:::
 # Effect Syntax
 ```yaml
 - id: quest_xp_multiplier

--- a/docs/ecoquests/ecoquests-effects/effects/start_quest.md
+++ b/docs/ecoquests/ecoquests-effects/effects/start_quest.md
@@ -1,13 +1,13 @@
 # `start_quest`
+:::infoRequires:
+EcoQuests
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Starts a quest for the player
-
-:::infoRequires:
-EcoQuests
-:::
 # Effect Syntax
 ```yaml
 - id: start_quest

--- a/docs/ecoquests/ecoquests-effects/filters/quest.md
+++ b/docs/ecoquests/ecoquests-effects/filters/quest.md
@@ -1,10 +1,9 @@
 # `quest`
-
-Require a certain quest
-
 :::infoRequires:
 EcoQuests
 :::
+
+Require a certain quest
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/ecoquests/ecoquests-effects/filters/task.md
+++ b/docs/ecoquests/ecoquests-effects/filters/task.md
@@ -1,10 +1,9 @@
 # `task`
-
-Require a certain task
-
 :::infoRequires:
 EcoQuests
 :::
+
+Require a certain task
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/ecoscrolls/ecoscrolls-effects/conditions/has_scroll.md
+++ b/docs/ecoscrolls/ecoscrolls-effects/conditions/has_scroll.md
@@ -1,10 +1,9 @@
 # `has_scroll`
-
-Requires a player to have a certain scroll active
-
 :::infoRequires:
 EcoScrolls
 :::
+
+Requires a player to have a certain scroll active
 # Condition Syntax
 ```yaml
 - id: has_scroll

--- a/docs/ecoscrolls/ecoscrolls-effects/effects/inscribe_item.md
+++ b/docs/ecoscrolls/ecoscrolls-effects/effects/inscribe_item.md
@@ -1,13 +1,13 @@
 # `inscribe_item`
+:::infoRequires:
+EcoScrolls
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Inscribes an item with a scroll
-
-:::infoRequires:
-EcoScrolls
-:::
 # Effect Syntax
 ```yaml
 - id: inscribe_item

--- a/docs/ecoscrolls/ecoscrolls-effects/filters/scroll.md
+++ b/docs/ecoscrolls/ecoscrolls-effects/filters/scroll.md
@@ -1,10 +1,9 @@
 # `scroll`
-
-Require a certain scroll
-
 :::infoRequires:
 EcoScrolls
 :::
+
+Require a certain scroll
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/ecoshop/ecoshop-effects/filters/shop_item.md
+++ b/docs/ecoshop/ecoshop-effects/filters/shop_item.md
@@ -1,10 +1,9 @@
 # `shop_item`
-
-Require a certain shop item
-
 :::infoRequires:
 EcoShop
 :::
+
+Require a certain shop item
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/ecoskills/ecoskills-effects/conditions/above_magic.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/above_magic.md
@@ -1,10 +1,9 @@
 # `above_magic`
-
-Requires a player to have a certain amount of magic
-
 :::infoRequires:
 EcoSkills
 :::
+
+Requires a player to have a certain amount of magic
 # Condition Syntax
 ```yaml
 - id: above_magic

--- a/docs/ecoskills/ecoskills-effects/conditions/below_magic.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/below_magic.md
@@ -1,10 +1,9 @@
 # `below_magic`
-
-Requires a player to have less than a certain amount of magic
-
 :::infoRequires:
 EcoSkills
 :::
+
+Requires a player to have less than a certain amount of magic
 # Condition Syntax
 ```yaml
 - id: below_magic

--- a/docs/ecoskills/ecoskills-effects/conditions/has_skill_level.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/has_skill_level.md
@@ -1,10 +1,9 @@
 # `has_skill_level`
-
-Requires a player to have a certain skill level
-
 :::infoRequires:
 EcoSkills
 :::
+
+Requires a player to have a certain skill level
 # Condition Syntax
 ```yaml
 - id: has_skill_level

--- a/docs/ecoskills/ecoskills-effects/conditions/stat_above.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/stat_above.md
@@ -1,10 +1,9 @@
 # `stat_above`
-
-Requires a player to have at least a certain stat level
-
 :::infoRequires:
 EcoSkills
 :::
+
+Requires a player to have at least a certain stat level
 # Condition Syntax
 
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/conditions/stat_below.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/stat_below.md
@@ -1,10 +1,9 @@
 # `stat_below`
-
-Requires a player to have less than a certain stat level
-
 :::infoRequires:
 EcoSkills
 :::
+
+Requires a player to have less than a certain stat level
 # Condition Syntax
 
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/conditions/stat_equals.md
+++ b/docs/ecoskills/ecoskills-effects/conditions/stat_equals.md
@@ -1,10 +1,9 @@
 # `stat_equals`
-
-Requires a player to have exactly a certain stat level
-
 :::infoRequires:
 EcoSkills
 :::
+
+Requires a player to have exactly a certain stat level
 # Condition Syntax
 
 ```yaml

--- a/docs/ecoskills/ecoskills-effects/effects/add_stat_temporarily.md
+++ b/docs/ecoskills/ecoskills-effects/effects/add_stat_temporarily.md
@@ -1,13 +1,13 @@
 # `add_stat_temporarily`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Adds a value to a specific stat
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: add_stat_temporarily

--- a/docs/ecoskills/ecoskills-effects/effects/give_magic.md
+++ b/docs/ecoskills/ecoskills-effects/effects/give_magic.md
@@ -1,13 +1,13 @@
 # `give_magic`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Add / subtract magic
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: give_magic

--- a/docs/ecoskills/ecoskills-effects/effects/give_skill_xp.md
+++ b/docs/ecoskills/ecoskills-effects/effects/give_skill_xp.md
@@ -1,13 +1,13 @@
 # `give_skill_xp`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a certain skill
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: give_skill_xp

--- a/docs/ecoskills/ecoskills-effects/effects/give_skill_xp_naturally.md
+++ b/docs/ecoskills/ecoskills-effects/effects/give_skill_xp_naturally.md
@@ -1,4 +1,8 @@
 # `give_skill_xp_naturally`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
@@ -6,10 +10,6 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 Gives naturally-gained experience points for a certain skill
 
 This will send a message to a player and will include multipliers.
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: give_skill_xp_naturally

--- a/docs/ecoskills/ecoskills-effects/effects/magic_regen_multiplier.md
+++ b/docs/ecoskills/ecoskills-effects/effects/magic_regen_multiplier.md
@@ -1,13 +1,13 @@
 # `magic_regen_multiplier`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies magic regeneration
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: magic_regen_multiplier

--- a/docs/ecoskills/ecoskills-effects/effects/make_skill_crit.md
+++ b/docs/ecoskills/ecoskills-effects/effects/make_skill_crit.md
@@ -1,13 +1,13 @@
 # `make_skill_crit`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Deal a crit hit
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: make_skill_crit

--- a/docs/ecoskills/ecoskills-effects/effects/multiply_all_stats.md
+++ b/docs/ecoskills/ecoskills-effects/effects/multiply_all_stats.md
@@ -1,13 +1,13 @@
 # `multiply_all_stats`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies all stats by a specific value
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: multiply_all_stats

--- a/docs/ecoskills/ecoskills-effects/effects/multiply_magic.md
+++ b/docs/ecoskills/ecoskills-effects/effects/multiply_magic.md
@@ -1,13 +1,13 @@
 # `multiply_magic`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Multiply magic
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: multiply_magic

--- a/docs/ecoskills/ecoskills-effects/effects/multiply_stat.md
+++ b/docs/ecoskills/ecoskills-effects/effects/multiply_stat.md
@@ -1,13 +1,13 @@
 # `multiply_stat`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies a stat by a specific value
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: multiply_stat

--- a/docs/ecoskills/ecoskills-effects/effects/multiply_stat_temporarily.md
+++ b/docs/ecoskills/ecoskills-effects/effects/multiply_stat_temporarily.md
@@ -1,13 +1,13 @@
 # `multiply_stat_temporarily`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Multiplies a stat by a specific value
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: multiply_stat_temporarily

--- a/docs/ecoskills/ecoskills-effects/filters/magic_type.md
+++ b/docs/ecoskills/ecoskills-effects/filters/magic_type.md
@@ -1,10 +1,9 @@
 # `magic_type`
-
-Require a certain magic type
-
 :::infoRequires:
 EcoSkills
 :::
+
+Require a certain magic type
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/ecoskills/ecoskills-effects/filters/skill.md
+++ b/docs/ecoskills/ecoskills-effects/filters/skill.md
@@ -1,10 +1,9 @@
 # `skill`
-
-Require a certain skill
-
 :::infoRequires:
 EcoSkills
 :::
+
+Require a certain skill
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-conditions/above_balance.md
+++ b/docs/effects/all-conditions/above_balance.md
@@ -1,10 +1,9 @@
 # `above_balance`
-
-Requires a player to have a certain amount of money
-
 :::infoRequires:
 Vault
 :::
+
+Requires a player to have a certain amount of money
 # Condition Syntax
 ```yaml
 - id: above_balance

--- a/docs/effects/all-conditions/above_magic.md
+++ b/docs/effects/all-conditions/above_magic.md
@@ -1,10 +1,9 @@
 # `above_magic`
-
-Requires a player to have a certain amount of magic
-
 :::infoRequires:
 EcoSkills
 :::
+
+Requires a player to have a certain amount of magic
 # Condition Syntax
 ```yaml
 - id: above_magic

--- a/docs/effects/all-conditions/below_balance.md
+++ b/docs/effects/all-conditions/below_balance.md
@@ -1,10 +1,9 @@
 # `below_balance`
-
-Requires a player to have below a certain amount of money
-
 :::infoRequires:
 Vault
 :::
+
+Requires a player to have below a certain amount of money
 # Condition Syntax
 ```yaml
 - id: below_balance

--- a/docs/effects/all-conditions/below_magic.md
+++ b/docs/effects/all-conditions/below_magic.md
@@ -1,10 +1,9 @@
 # `below_magic`
-
-Requires a player to have less than a certain amount of magic
-
 :::infoRequires:
 EcoSkills
 :::
+
+Requires a player to have less than a certain amount of magic
 # Condition Syntax
 ```yaml
 - id: below_magic

--- a/docs/effects/all-conditions/has_active_job.md
+++ b/docs/effects/all-conditions/has_active_job.md
@@ -1,10 +1,9 @@
 # `has_active_job`
-
-Requires a player to have a job active
-
 :::infoRequires:
 EcoJobs
 :::
+
+Requires a player to have a job active
 # Condition Syntax
 ```yaml
 - id: has_active_job

--- a/docs/effects/all-conditions/has_active_pet.md
+++ b/docs/effects/all-conditions/has_active_pet.md
@@ -1,10 +1,9 @@
 # `has_active_pet`
-
-Requires a player to have a pet active
-
 :::infoRequires:
 EcoPets
 :::
+
+Requires a player to have a pet active
 # Condition Syntax
 ```yaml
 - id: has_active_pet

--- a/docs/effects/all-conditions/has_battlepass_tier.md
+++ b/docs/effects/all-conditions/has_battlepass_tier.md
@@ -1,10 +1,9 @@
 # `has_battlepass_tier`
-
-Requires a player to have a certain battlepass tier
-
 :::infoRequires:
 xBattlepass
 :::
+
+Requires a player to have a certain battlepass tier
 # Condition Syntax
 ```yaml
 - id: has_battlepass_tier

--- a/docs/effects/all-conditions/has_boss_bar_visible.md
+++ b/docs/effects/all-conditions/has_boss_bar_visible.md
@@ -1,10 +1,9 @@
 # `has_boss_bar_visible`
-
-Requires a player to have the TAB boss bar shown to them
-
 :::infoRequires:
 TAB
 :::
+
+Requires a player to have the TAB boss bar shown to them
 # Condition Syntax
 ```yaml
 - id: has_boss_bar_visible

--- a/docs/effects/all-conditions/has_completed_quest.md
+++ b/docs/effects/all-conditions/has_completed_quest.md
@@ -1,10 +1,9 @@
 # `has_completed_quest`
-
-Requires a player to have completed a quest
-
 :::infoRequires:
 EcoQuests
 :::
+
+Requires a player to have completed a quest
 # Condition Syntax
 ```yaml
 - id: has_completed_quest

--- a/docs/effects/all-conditions/has_completed_task.md
+++ b/docs/effects/all-conditions/has_completed_task.md
@@ -1,10 +1,9 @@
 # `has_completed_task`
-
-Requires a player to have completed task for a quest
-
 :::infoRequires:
 EcoQuests
 :::
+
+Requires a player to have completed task for a quest
 # Condition Syntax
 ```yaml
 - id: has_completed_task

--- a/docs/effects/all-conditions/has_ecoitem.md
+++ b/docs/effects/all-conditions/has_ecoitem.md
@@ -1,10 +1,9 @@
 # `has_ecoitem`
-
-Requires a player to have a certain EcoItem active
-
 :::infoRequires:
 EcoItems
 :::
+
+Requires a player to have a certain EcoItem active
 # Condition Syntax
 ```yaml
 - id: has_ecoitem

--- a/docs/effects/all-conditions/has_job_level.md
+++ b/docs/effects/all-conditions/has_job_level.md
@@ -1,10 +1,9 @@
 # `has_job_level`
-
-Requires a player to have a certain job level
-
 :::infoRequires:
 EcoJobs
 :::
+
+Requires a player to have a certain job level
 # Condition Syntax
 ```yaml
 - id: has_job_level

--- a/docs/effects/all-conditions/has_lands_role.md
+++ b/docs/effects/all-conditions/has_lands_role.md
@@ -1,10 +1,9 @@
 # `has_lands_role`
-
-Requires a player to have a certain role in the Land
-
 :::infoRequires:
 Lands
 :::
+
+Requires a player to have a certain role in the Land
 # Condition Syntax
 ```yaml
 - id: has_lands_role

--- a/docs/effects/all-conditions/has_mana.md
+++ b/docs/effects/all-conditions/has_mana.md
@@ -1,10 +1,9 @@
 # `has_mana`
-
-Requires a player to have amount of mana
-
 :::infoRequires:
 AuraSkills
 :::
+
+Requires a player to have amount of mana
 # Condition Syntax
 ```yaml
 - id: has_mana

--- a/docs/effects/all-conditions/has_mcmmo_level.md
+++ b/docs/effects/all-conditions/has_mcmmo_level.md
@@ -1,10 +1,9 @@
 # `has_mcmmo_level`
-
-Requires a player to have a certain McMMO skill level
-
 :::infoRequires:
 McMMO
 :::
+
+Requires a player to have a certain McMMO skill level
 # Condition Syntax
 ```yaml
 - id: has_mcmmo_level

--- a/docs/effects/all-conditions/has_pet.md
+++ b/docs/effects/all-conditions/has_pet.md
@@ -1,10 +1,9 @@
 # `has_pet`
-
-Requires a player to have a certain pet
-
 :::infoRequires:
 EcoPets
 :::
+
+Requires a player to have a certain pet
 # Condition Syntax
 ```yaml
 - id: has_pet

--- a/docs/effects/all-conditions/has_pet_level.md
+++ b/docs/effects/all-conditions/has_pet_level.md
@@ -1,10 +1,9 @@
 # `has_pet_level`
-
-Requires a player to have a certain pet level
-
 :::infoRequires:
 EcoPets
 :::
+
+Requires a player to have a certain pet level
 # Condition Syntax
 ```yaml
 - id: has_pet_level

--- a/docs/effects/all-conditions/has_premium_battlepass.md
+++ b/docs/effects/all-conditions/has_premium_battlepass.md
@@ -1,10 +1,9 @@
 # `has_premium_battlepass`
-
-Requires a player to have the premium battlepass
-
 :::infoRequires:
 xBattlepass
 :::
+
+Requires a player to have the premium battlepass
 # Condition Syntax
 ```yaml
 - id: has_premium_battlepass

--- a/docs/effects/all-conditions/has_quest_active.md
+++ b/docs/effects/all-conditions/has_quest_active.md
@@ -1,10 +1,9 @@
 # `has_quest_active`
-
-Requires a player to have a quest active
-
 :::infoRequires:
 EcoQuests
 :::
+
+Requires a player to have a quest active
 # Condition Syntax
 ```yaml
 - id: has_quest_active

--- a/docs/effects/all-conditions/has_reforge.md
+++ b/docs/effects/all-conditions/has_reforge.md
@@ -1,11 +1,9 @@
 # `has_reforge`
-
-Requires a player to have a certain reforge active
-
-
 :::infoRequires:
 Reforges
 :::
+
+Requires a player to have a certain reforge active
 # Condition Syntax
 ```yaml
 - id: has_reforge

--- a/docs/effects/all-conditions/has_scoreboard_visible.md
+++ b/docs/effects/all-conditions/has_scoreboard_visible.md
@@ -1,10 +1,9 @@
 # `has_scoreboard_visible`
-
-Requires a player to have the TAB scoreboard shown to them
-
 :::infoRequires:
 TAB
 :::
+
+Requires a player to have the TAB scoreboard shown to them
 # Condition Syntax
 ```yaml
 - id: has_scoreboard_visible

--- a/docs/effects/all-conditions/has_scroll.md
+++ b/docs/effects/all-conditions/has_scroll.md
@@ -1,10 +1,9 @@
 # `has_scroll`
-
-Requires a player to have a certain scroll active
-
 :::infoRequires:
 EcoScrolls
 :::
+
+Requires a player to have a certain scroll active
 # Condition Syntax
 ```yaml
 - id: has_scroll

--- a/docs/effects/all-conditions/has_skill_level.md
+++ b/docs/effects/all-conditions/has_skill_level.md
@@ -1,10 +1,9 @@
 # `has_skill_level`
-
-Requires a player to have a certain skill level
-
 :::infoRequires:
 EcoSkills / AuraSkills
 :::
+
+Requires a player to have a certain skill level
 # Condition Syntax
 ```yaml
 - id: has_skill_level

--- a/docs/effects/all-conditions/has_talisman.md
+++ b/docs/effects/all-conditions/has_talisman.md
@@ -1,11 +1,9 @@
 # `has_talisman`
-
-Requires a player to have a certain talisman active
-
-
 :::infoRequires:
 Talismans
 :::
+
+Requires a player to have a certain talisman active
 # Condition Syntax
 ```yaml
 - id: has_talisman

--- a/docs/effects/all-conditions/has_town_role.md
+++ b/docs/effects/all-conditions/has_town_role.md
@@ -1,10 +1,9 @@
 # `has_town_role`
-
-Requires a player to have a certain role in a town
-
 :::infoRequires:
 HuskTowns
 :::
+
+Requires a player to have a certain role in a town
 # Condition Syntax
 ```yaml
 - id: has_town_role

--- a/docs/effects/all-conditions/in_bubble.md
+++ b/docs/effects/all-conditions/in_bubble.md
@@ -1,10 +1,9 @@
 # `in_bubble`
-
-Requires a player to be in a bubble column
-
 :::infoRequires:
 Paper
 :::
+
+Requires a player to be in a bubble column
 # Condition Syntax
 ```yaml
 - id: in_bubble

--- a/docs/effects/all-conditions/in_lava.md
+++ b/docs/effects/all-conditions/in_lava.md
@@ -1,10 +1,9 @@
 # `in_lava`
-
-Requires a player to be in lava
-
 :::infoRequires:
 Paper
 :::
+
+Requires a player to be in lava
 # Condition Syntax
 ```yaml
 - id: in_lava

--- a/docs/effects/all-conditions/in_own_claim.md
+++ b/docs/effects/all-conditions/in_own_claim.md
@@ -1,10 +1,9 @@
 # `in_own_claim`
-
-Requires the player to be in their own claim
-
 :::infoRequires:
 HuskClaims || HuskTowns || Lands
 :::
+
+Requires the player to be in their own claim
 # Condition Syntax
 ```yaml
 - id: in_own_claim

--- a/docs/effects/all-conditions/in_rain.md
+++ b/docs/effects/all-conditions/in_rain.md
@@ -1,10 +1,9 @@
 # `in_rain`
-
-Requires a player to be in rain
-
 :::infoRequires:
 Paper
 :::
+
+Requires a player to be in rain
 # Condition Syntax
 ```yaml
 - id: in_rain

--- a/docs/effects/all-conditions/in_region.md
+++ b/docs/effects/all-conditions/in_region.md
@@ -1,11 +1,9 @@
 # `in_region`
-
-Requires a player to be in a certain region
-
-
 :::infoRequires:
 WorldGuard
 :::
+
+Requires a player to be in a certain region
 # Condition Syntax
 ```yaml
 - id: in_region

--- a/docs/effects/all-conditions/in_trusted_claim.md
+++ b/docs/effects/all-conditions/in_trusted_claim.md
@@ -1,10 +1,9 @@
 # `in_trusted_claim`
-
-Requires the player to be in a claim they're trusted in
-
 :::infoRequires:
 Lands
 :::
+
+Requires the player to be in a claim they're trusted in
 # Condition Syntax
 ```yaml
 - id: in_trusted_claim

--- a/docs/effects/all-conditions/is_booster_active.md
+++ b/docs/effects/all-conditions/is_booster_active.md
@@ -1,10 +1,9 @@
 # `is_booster_active`
-
-Requires a certain booster to be active on the server
-
 :::infoRequires:
 Boosters
 :::
+
+Requires a certain booster to be active on the server
 # Condition Syntax
 ```yaml
 - id: is_booster_active

--- a/docs/effects/all-conditions/is_season.md
+++ b/docs/effects/all-conditions/is_season.md
@@ -1,10 +1,9 @@
 # `is_season`
-
-Requires it to be a certain season
-
 :::infoRequires:
 CustomCrops
 :::
+
+Requires it to be a certain season
 # Condition Syntax
 ```yaml
 - id: is_season

--- a/docs/effects/all-conditions/is_wearing_set.md
+++ b/docs/effects/all-conditions/is_wearing_set.md
@@ -1,10 +1,9 @@
 # `is_wearing_set`
-
-Requires a player to be wearing a certain EcoArmor set
-
 :::infoRequires:
 EcoArmor
 :::
+
+Requires a player to be wearing a certain EcoArmor set
 # Condition Syntax
 ```yaml
 - id: is_wearing_set

--- a/docs/effects/all-conditions/lands_balance_above.md
+++ b/docs/effects/all-conditions/lands_balance_above.md
@@ -1,10 +1,9 @@
 # `lands_balance_above`
-
-Requires the Land's bank balance to be above a value
-
 :::infoRequires:
 Lands
 :::
+
+Requires the Land's bank balance to be above a value
 # Condition Syntax
 ```yaml
 - id: lands_balance_above

--- a/docs/effects/all-conditions/lands_balance_below.md
+++ b/docs/effects/all-conditions/lands_balance_below.md
@@ -1,10 +1,9 @@
 # `lands_balance_below`
-
-Requires the Land's bank balance to be below a value
-
 :::infoRequires:
 Lands
 :::
+
+Requires the Land's bank balance to be below a value
 # Condition Syntax
 ```yaml
 - id: lands_balance_below

--- a/docs/effects/all-conditions/lands_balance_equal.md
+++ b/docs/effects/all-conditions/lands_balance_equal.md
@@ -1,10 +1,9 @@
 # `lands_balance_equal`
-
-Requires the Land's bank balance to be equal to a value
-
 :::infoRequires:
 Lands
 :::
+
+Requires the Land's bank balance to be equal to a value
 # Condition Syntax
 ```yaml
 - id: lands_balance_equal

--- a/docs/effects/all-conditions/mcmmo_ability_on_cooldown.md
+++ b/docs/effects/all-conditions/mcmmo_ability_on_cooldown.md
@@ -1,10 +1,9 @@
 # `mcmmo_ability_on_cooldown`
-
-Requires an McMMO ability to be on cooldown
-
 :::infoRequires:
 McMMO
 :::
+
+Requires an McMMO ability to be on cooldown
 # Condition Syntax
 ```yaml
 - id: mcmmo_ability_on_cooldown

--- a/docs/effects/all-conditions/stat_above.md
+++ b/docs/effects/all-conditions/stat_above.md
@@ -1,10 +1,9 @@
 # `stat_above`
-
-Requires a player to have at least a certain stat level
-
 :::infoRequires:
 EcoSkills
 :::
+
+Requires a player to have at least a certain stat level
 # Condition Syntax
 
 ```yaml

--- a/docs/effects/all-conditions/stat_below.md
+++ b/docs/effects/all-conditions/stat_below.md
@@ -1,10 +1,9 @@
 # `stat_below`
-
-Requires a player to have less than a certain stat level
-
 :::infoRequires:
 EcoSkills
 :::
+
+Requires a player to have less than a certain stat level
 # Condition Syntax
 
 ```yaml

--- a/docs/effects/all-conditions/stat_equals.md
+++ b/docs/effects/all-conditions/stat_equals.md
@@ -1,10 +1,9 @@
 # `stat_equals`
-
-Requires a player to have exactly a certain stat level
-
 :::infoRequires:
 EcoSkills
 :::
+
+Requires a player to have exactly a certain stat level
 # Condition Syntax
 
 ```yaml

--- a/docs/effects/all-effects/add_durability.md
+++ b/docs/effects/all-effects/add_durability.md
@@ -1,13 +1,13 @@
 # `add_durability`
+:::infoRequires:
+Server Version 1.21+
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Increase the max durability of an item
-
-:::infoRequires:
-Server Version 1.21+
-:::
 # Effect Syntax
 ```yaml
 - id: add_durability

--- a/docs/effects/all-effects/add_stat.md
+++ b/docs/effects/all-effects/add_stat.md
@@ -1,13 +1,13 @@
 # `add_stat`
+:::infoRequires:
+EcoSkills / AuraSkills
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Adds a value to a specific stat
-
-:::infoRequires:
-EcoSkills / AuraSkills
-:::
 # Effect Syntax
 ```yaml
 - id: add_stat

--- a/docs/effects/all-effects/add_stat_temporarily.md
+++ b/docs/effects/all-effects/add_stat_temporarily.md
@@ -1,13 +1,13 @@
 # `add_stat_temporarily`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Adds a value to a specific stat
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: add_stat_temporarily

--- a/docs/effects/all-effects/battlepass_task_xp_multiplier.md
+++ b/docs/effects/all-effects/battlepass_task_xp_multiplier.md
@@ -1,13 +1,13 @@
 # `battlepass_task_xp_multiplier`
+:::infoRequires:
+xBattlepass
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies incoming battlepass task xp gain
-
-:::infoRequires:
-xBattlepass
-:::
 # Effect Syntax
 ```yaml
 - id: battlepass_task_xp_multiplier

--- a/docs/effects/all-effects/battlepass_xp_multiplier.md
+++ b/docs/effects/all-effects/battlepass_xp_multiplier.md
@@ -1,13 +1,13 @@
 # `battlepass_xp_multiplier`
+:::infoRequires:
+xBattlepass
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies incoming battlepass xp gain
-
-:::infoRequires:
-xBattlepass
-:::
 # Effect Syntax
 ```yaml
 - id: battlepassxp_multiplier

--- a/docs/effects/all-effects/block_reach.md
+++ b/docs/effects/all-effects/block_reach.md
@@ -1,13 +1,13 @@
 # `block_reach`
+:::infoRequires:
+Server Version 1.21+
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Adds reach for interacting with blocks
-
-:::infoRequires:
-Server Version 1.21+
-:::
 # Effect Syntax
 ```yaml
 - id: block_reach

--- a/docs/effects/all-effects/burning_time_multiplier.md
+++ b/docs/effects/all-effects/burning_time_multiplier.md
@@ -1,13 +1,13 @@
 # `burning_time_multiplier`
+:::infoRequires:
+Server Version 1.21+
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies how long an entity is on fire after being ignited
-
-:::infoRequires:
-Server Version 1.21+
-:::
 # Effect Syntax
 ```yaml
 - id: burning_time_multiplier

--- a/docs/effects/all-effects/drop_pickup_item.md
+++ b/docs/effects/all-effects/drop_pickup_item.md
@@ -1,13 +1,13 @@
 # `drop_pickup_item`
+:::infoRequires:
+Paper
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Drops an item that runs a chain on pickup
-
-:::infoRequires:
-Paper
-:::
 # Effect Syntax
 
 ```yaml

--- a/docs/effects/all-effects/entity_reach.md
+++ b/docs/effects/all-effects/entity_reach.md
@@ -1,13 +1,13 @@
 # `entity_reach`
+:::infoRequires:
+Server Version 1.21+
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Adds reach for interacting with entities
-
-:::infoRequires:
-Server Version 1.21+
-:::
 # Effect Syntax
 ```yaml
 - id: entity_reach

--- a/docs/effects/all-effects/explosion_knockback_resistance_multiplier.md
+++ b/docs/effects/all-effects/explosion_knockback_resistance_multiplier.md
@@ -1,13 +1,13 @@
 # `explosion_knockback_resistance_multiplier`
+:::infoRequires:
+Server Version 1.21+
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies explosion resistance
-
-:::infoRequires:
-Server Version 1.21+
-:::
 # Effect Syntax
 ```yaml
 - id: explosion_knockback_resistance_multiplier

--- a/docs/effects/all-effects/gain_task_xp.md
+++ b/docs/effects/all-effects/gain_task_xp.md
@@ -1,13 +1,13 @@
 # `gain_task_xp`
+:::infoRequires:
+EcoQuests
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gains experience points for a task in a quest, including multipliers.
-
-:::infoRequires:
-EcoQuests
-:::
 # Effect Syntax
 
 ```yaml

--- a/docs/effects/all-effects/give_battlepass_task_xp.md
+++ b/docs/effects/all-effects/give_battlepass_task_xp.md
@@ -1,13 +1,13 @@
 # `give_battlepass_task_xp`
+:::infoRequires:
+xBattlepass
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a task in a quest, excluding multipliers.
-
-:::infoRequires:
-xBattlepass
-:::
 # Effect Syntax
 ```yaml
 - id: give_battlepass_task_xp

--- a/docs/effects/all-effects/give_battlepass_tier.md
+++ b/docs/effects/all-effects/give_battlepass_tier.md
@@ -1,13 +1,13 @@
 # `give_battlepass_tier`
+:::infoRequires:
+xBattlepass
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Give battlepass tiers to the player.
-
-:::infoRequires:
-xBattlepass
-:::
 # Effect Syntax
 ```yaml
 - id: give_battlepass_tier

--- a/docs/effects/all-effects/give_battlepass_xp.md
+++ b/docs/effects/all-effects/give_battlepass_xp.md
@@ -1,13 +1,13 @@
 # `give_battlepass_xp`
+:::infoRequires:
+xBattlepass
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Give battlepass experience points
-
-:::infoRequires:
-xBattlepass
-:::
 # Effect Syntax
 ```yaml
 - id: give_battlepass_xp

--- a/docs/effects/all-effects/give_job_xp.md
+++ b/docs/effects/all-effects/give_job_xp.md
@@ -1,13 +1,13 @@
 # `give_job_xp`
+:::infoRequires:
+EcoJobs
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a certain job
-
-:::infoRequires:
-EcoJobs
-:::
 # Effect Syntax
 ```yaml
 - id: give_job_xp

--- a/docs/effects/all-effects/give_lands_balance.md
+++ b/docs/effects/all-effects/give_lands_balance.md
@@ -1,13 +1,13 @@
 # `give_lands_balance`
+:::infoRequires:
+Lands
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Give money to a Land's bank balance
-
-:::infoRequires:
-Lands
-:::
 # Effect Syntax
 
 ```yaml

--- a/docs/effects/all-effects/give_magic.md
+++ b/docs/effects/all-effects/give_magic.md
@@ -1,13 +1,13 @@
 # `give_magic`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Add / subtract magic
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: give_magic

--- a/docs/effects/all-effects/give_mcmmo_xp.md
+++ b/docs/effects/all-effects/give_mcmmo_xp.md
@@ -1,13 +1,13 @@
 # `give_mcmmo_xp`
+:::infoRequires:
+McMMO
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a certain skill
-
-:::infoRequires:
-McMMO
-:::
 # Effect Syntax
 ```yaml
 - id: give_mcmmo_xp

--- a/docs/effects/all-effects/give_money.md
+++ b/docs/effects/all-effects/give_money.md
@@ -1,13 +1,13 @@
 # `give_money`
+:::infoRequires:
+Vault
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives a player money
-
-:::infoRequires:
-Vault
-:::
 # Effect Syntax
 ```yaml
 - id: give_money

--- a/docs/effects/all-effects/give_permission.md
+++ b/docs/effects/all-effects/give_permission.md
@@ -1,13 +1,13 @@
 # `give_permission`
+:::infoRequires:
+Vault
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Gives a permission while active
-
-:::infoRequires:
-Vault
-:::
 # Effect Syntax
 ```yaml
 - id: give_permission

--- a/docs/effects/all-effects/give_pet_xp.md
+++ b/docs/effects/all-effects/give_pet_xp.md
@@ -1,13 +1,13 @@
 # `give_pet_xp`
+:::infoRequires:
+EcoPets
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a certain pet
-
-:::infoRequires:
-EcoPets
-:::
 # Effect Syntax
 ```yaml
 - id: give_pet_xp

--- a/docs/effects/all-effects/give_skill_xp.md
+++ b/docs/effects/all-effects/give_skill_xp.md
@@ -1,13 +1,13 @@
 # `give_skill_xp`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a certain skill
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: give_skill_xp

--- a/docs/effects/all-effects/give_skill_xp_naturally.md
+++ b/docs/effects/all-effects/give_skill_xp_naturally.md
@@ -1,4 +1,8 @@
 # `give_skill_xp_naturally`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
@@ -6,10 +10,6 @@ This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers
 Gives naturally-gained experience points for a certain skill
 
 This will send a message to a player and will include multipliers.
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: give_skill_xp_naturally

--- a/docs/effects/all-effects/give_task_xp.md
+++ b/docs/effects/all-effects/give_task_xp.md
@@ -1,13 +1,13 @@
 # `give_task_xp`
+:::infoRequires:
+EcoQuests
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a task in a quest, excluding multipliers.
-
-:::infoRequires:
-EcoQuests
-:::
 # Effect Syntax
 
 ```yaml

--- a/docs/effects/all-effects/gravity_multiplier.md
+++ b/docs/effects/all-effects/gravity_multiplier.md
@@ -1,13 +1,13 @@
 # `gravity_multiplier`
+:::infoRequires:
+Server Version 1.21+
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies gravity
-
-:::infoRequires:
-Server Version 1.21+
-:::
 # Effect Syntax
 ```yaml
 - id: gravity_multiplier

--- a/docs/effects/all-effects/increase_step_height.md
+++ b/docs/effects/all-effects/increase_step_height.md
@@ -1,13 +1,13 @@
 # `increase_step_height`
+:::infoRequires:
+Server Version 1.21+
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Increases the amount of blocks you can walk over without jumping
-
-:::infoRequires:
-Server Version 1.21+
-:::
 # Effect Syntax
 ```yaml
 - id: increase_step_height

--- a/docs/effects/all-effects/inscribe_item.md
+++ b/docs/effects/all-effects/inscribe_item.md
@@ -1,13 +1,13 @@
 # `inscribe_item`
+:::infoRequires:
+EcoScrolls
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Inscribes an item with a scroll
-
-:::infoRequires:
-EcoScrolls
-:::
 # Effect Syntax
 
 ```yaml

--- a/docs/effects/all-effects/job_xp_multiplier.md
+++ b/docs/effects/all-effects/job_xp_multiplier.md
@@ -1,13 +1,13 @@
 # `job_xp_multiplier`
+:::infoRequires:
+EcoJobs
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies job xp gain
-
-:::infoRequires:
-EcoJobs
-:::
 # Effect Syntax
 ```yaml
 - id: job_xp_multiplier

--- a/docs/effects/all-effects/jobs_money_multiplier.md
+++ b/docs/effects/all-effects/jobs_money_multiplier.md
@@ -1,14 +1,13 @@
 # `jobs_money_multiplier`
+:::infoRequires:
+Jobs Reborn
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies money gain from jobs
-
-
-:::infoRequires:
-Jobs Reborn
-:::
 # Effect Syntax
 ```yaml
 - id: jobs_money_multiplier

--- a/docs/effects/all-effects/jobs_xp_multiplier.md
+++ b/docs/effects/all-effects/jobs_xp_multiplier.md
@@ -1,14 +1,13 @@
 # `jobs_xp_multiplier`
+:::infoRequires:
+Jobs Reborn
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies xp gain from jobs
-
-
-:::infoRequires:
-Jobs Reborn
-:::
 # Effect Syntax
 ```yaml
 - id: jobs_xp_multiplier

--- a/docs/effects/all-effects/jump_strength_multiplier.md
+++ b/docs/effects/all-effects/jump_strength_multiplier.md
@@ -1,13 +1,13 @@
 # `jump_strength_multiplier`
+:::infoRequires:
+Server Version 1.21+
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies jump strength
-
-:::infoRequires:
-Server Version 1.21+
-:::
 # Effect Syntax
 ```yaml
 - id: jump_strength_multiplier

--- a/docs/effects/all-effects/magic_regen_multiplier.md
+++ b/docs/effects/all-effects/magic_regen_multiplier.md
@@ -1,13 +1,13 @@
 # `magic_regen_multiplier`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies magic regeneration
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: magic_regen_multiplier

--- a/docs/effects/all-effects/make_skill_crit.md
+++ b/docs/effects/all-effects/make_skill_crit.md
@@ -1,13 +1,13 @@
 # `make_skill_crit`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Deal a crit hit
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: make_skill_crit

--- a/docs/effects/all-effects/mcmmo_xp_multiplier.md
+++ b/docs/effects/all-effects/mcmmo_xp_multiplier.md
@@ -1,13 +1,13 @@
 # `mcmmo_xp_multiplier`
+:::infoRequires:
+McMMO
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies mcMMO skill xp gain
-
-:::infoRequires:
-McMMO
-:::
 # Effect Syntax
 ```yaml
 - id: mcmmo_xp_multiplier

--- a/docs/effects/all-effects/mining_efficiency.md
+++ b/docs/effects/all-effects/mining_efficiency.md
@@ -1,13 +1,13 @@
 # `mining_efficiency`
+:::infoRequires:
+Server Version 1.21+
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Adds mining efficiency (mining speed when using the correct tool)
-
-:::infoRequires:
-Server Version 1.21+
-:::
 # Effect Syntax
 ```yaml
 - id: mining_efficiency

--- a/docs/effects/all-effects/mining_speed_multiplier.md
+++ b/docs/effects/all-effects/mining_speed_multiplier.md
@@ -1,13 +1,13 @@
 # `mining_speed_multiplier`
+:::infoRequires:
+Server Version 1.21+
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies mining speed
-
-:::infoRequires:
-Server Version 1.21+
-:::
 # Effect Syntax
 ```yaml
 - id: mining_speed_multiplier

--- a/docs/effects/all-effects/mob_coins_chance_multiplier.md
+++ b/docs/effects/all-effects/mob_coins_chance_multiplier.md
@@ -1,14 +1,13 @@
 # `mob_coins_chance_multiplier`
+:::infoRequires:
+UltimateMobCoins
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies the chance of mobcoins being dropped
-
-
-:::infoRequires:
-UltimateMobCoins
-:::
 # Effect Syntax
 ```yaml
 - id: mob_coins_chance_multiplier

--- a/docs/effects/all-effects/mob_coins_drop_multiplier.md
+++ b/docs/effects/all-effects/mob_coins_drop_multiplier.md
@@ -1,14 +1,13 @@
 # `mob_coins_drop_multiplier`
+:::infoRequires:
+UltimateMobCoins
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies the mobcoins dropped
-
-
-:::infoRequires:
-UltimateMobCoins
-:::
 # Effect Syntax
 ```yaml
 - id: mob_coins_drop_multiplier

--- a/docs/effects/all-effects/mob_coins_multiplier.md
+++ b/docs/effects/all-effects/mob_coins_multiplier.md
@@ -1,13 +1,13 @@
 # `mob_coins_multiplier`
+:::infoRequires:
+Flare Mobcoins
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies mob coin drops
-
-:::infoRequires:
-Flare Mobcoins
-:::
 # Effect Syntax
 ```yaml
 - id: mob_coins_multiplier

--- a/docs/effects/all-effects/movement_efficiency_multiplier.md
+++ b/docs/effects/all-effects/movement_efficiency_multiplier.md
@@ -1,13 +1,13 @@
 # `movement_efficiency_multiplier`
+:::infoRequires:
+Server Version 1.21+
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies movement speed through difficult terrain
-
-:::infoRequires:
-Server Version 1.21+
-:::
 # Effect Syntax
 ```yaml
 - id: movement_efficiency_multiplier

--- a/docs/effects/all-effects/multiply_all_stats.md
+++ b/docs/effects/all-effects/multiply_all_stats.md
@@ -1,13 +1,13 @@
 # `multiply_all_stats`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies all stats by a specific value
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: multiply_all_stats

--- a/docs/effects/all-effects/multiply_magic.md
+++ b/docs/effects/all-effects/multiply_magic.md
@@ -1,13 +1,13 @@
 # `multiply_magic`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Multiply magic
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: multiply_magic

--- a/docs/effects/all-effects/multiply_stat.md
+++ b/docs/effects/all-effects/multiply_stat.md
@@ -1,13 +1,13 @@
 # `multiply_stat`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies a stat by a specific value
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: multiply_stat

--- a/docs/effects/all-effects/multiply_stat_temporarily.md
+++ b/docs/effects/all-effects/multiply_stat_temporarily.md
@@ -1,13 +1,13 @@
 # `multiply_stat_temporarily`
+:::infoRequires:
+EcoSkills
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Multiplies a stat by a specific value
-
-:::infoRequires:
-EcoSkills
-:::
 # Effect Syntax
 ```yaml
 - id: multiply_stat_temporarily

--- a/docs/effects/all-effects/pet_xp_multiplier.md
+++ b/docs/effects/all-effects/pet_xp_multiplier.md
@@ -1,13 +1,13 @@
 # `pet_xp_multiplier`
+:::infoRequires:
+EcoPets
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies pet xp gain
-
-:::infoRequires:
-EcoPets
-:::
 # Effect Syntax
 ```yaml
 - id: pet_xp_multiplier

--- a/docs/effects/all-effects/play_animation.md
+++ b/docs/effects/all-effects/play_animation.md
@@ -1,14 +1,13 @@
 # `play_animation`
+:::infoRequires:
+Model Engine
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Plays a Model Engine animation (The entity must have a custom model active)
-
-
-:::infoRequires:
-Model Engine
-:::
 # Effect Syntax
 ```yaml
 - id: play_animation

--- a/docs/effects/all-effects/quest_xp_multiplier.md
+++ b/docs/effects/all-effects/quest_xp_multiplier.md
@@ -1,13 +1,13 @@
 # `quest_xp_multiplier`
+:::infoRequires:
+EcoQuests
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies quest xp gain
-
-:::infoRequires:
-EcoQuests
-:::
 # Effect Syntax
 ```yaml
 - id: quest_xp_multiplier

--- a/docs/effects/all-effects/safe_fall_distance.md
+++ b/docs/effects/all-effects/safe_fall_distance.md
@@ -1,13 +1,13 @@
 # `safe_fall_distance`
+:::infoRequires:
+Server Version 1.21+
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Increases/decreases the distance you can fall without taking damage
-
-:::infoRequires:
-Server Version 1.21+
-:::
 # Effect Syntax
 ```yaml
 - id: safe_fall_distance

--- a/docs/effects/all-effects/scale.md
+++ b/docs/effects/all-effects/scale.md
@@ -1,13 +1,13 @@
 # `scale`
+:::infoRequires:
+Server Version 1.21+
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies scale
-
-:::infoRequires:
-Server Version 1.21+
-:::
 # Effect Syntax
 ```yaml
 - id: scale

--- a/docs/effects/all-effects/send_minimessage.md
+++ b/docs/effects/all-effects/send_minimessage.md
@@ -1,13 +1,13 @@
 # `send_minimessage`
+:::infoRequires:
+Paper
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Sends the player a minimessage message, supports clickable components, etc.
-
-:::infoRequires:
-Paper
-:::
 # Effect Syntax
 ```yaml
 - id: send_minimessage

--- a/docs/effects/all-effects/set_battlepass_tier.md
+++ b/docs/effects/all-effects/set_battlepass_tier.md
@@ -1,13 +1,13 @@
 # `set_battlepass_tier`
+:::infoRequires:
+xBattlepass
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Set the player's battlepass tier
-
-:::infoRequires:
-xBattlepass
-:::
 # Effect Syntax
 ```yaml
 - id: set_battlepass_tier

--- a/docs/effects/all-effects/set_lands_balance.md
+++ b/docs/effects/all-effects/set_lands_balance.md
@@ -1,13 +1,13 @@
 # `set_lands_balance`
+:::infoRequires:
+Lands
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Set the Land bank's balance
-
-:::infoRequires:
-Lands
-:::
 # Effect Syntax
 
 ```yaml

--- a/docs/effects/all-effects/skill_xp_multiplier.md
+++ b/docs/effects/all-effects/skill_xp_multiplier.md
@@ -1,13 +1,13 @@
 # `skill_xp_multiplier`
+:::infoRequires:
+EcoSkills || AuraSkills
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies skill xp gain
-
-:::infoRequires:
-EcoSkills || AuraSkills
-:::
 # Effect Syntax
 ```yaml
 - id: skill_xp_multiplier

--- a/docs/effects/all-effects/sneaking_speed_multiplier.md
+++ b/docs/effects/all-effects/sneaking_speed_multiplier.md
@@ -1,13 +1,13 @@
 # `sneaking_speed_multiplier`
+:::infoRequires:
+Server Version 1.21+
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies sneaking speed
-
-:::infoRequires:
-Server Version 1.21+
-:::
 # Effect Syntax
 ```yaml
 - id: sneaking_speed_multiplier

--- a/docs/effects/all-effects/start_quest.md
+++ b/docs/effects/all-effects/start_quest.md
@@ -1,13 +1,13 @@
 # `start_quest`
+:::infoRequires:
+EcoQuests
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Starts a quest for the player
-
-:::infoRequires:
-EcoQuests
-:::
 # Effect Syntax
 
 ```yaml

--- a/docs/effects/all-effects/take_money.md
+++ b/docs/effects/all-effects/take_money.md
@@ -1,13 +1,13 @@
 # `take_money`
+:::infoRequires:
+Vault
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Takes money from the player
-
-:::infoRequires:
-Vault
-:::
 # Effect Syntax
 ```yaml
 - id: take_money

--- a/docs/effects/all-effects/underwater_mining_speed_multiplier.md
+++ b/docs/effects/all-effects/underwater_mining_speed_multiplier.md
@@ -1,13 +1,13 @@
 # `underwater_mining_speed_multiplier`
+:::infoRequires:
+Server Version 1.21+
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies underwater mining speed
-
-:::infoRequires:
-Server Version 1.21+
-:::
 # Effect Syntax
 ```yaml
 - id: underwater_mining_speed_multiplier

--- a/docs/effects/all-effects/water_movement_efficiency_multiplier.md
+++ b/docs/effects/all-effects/water_movement_efficiency_multiplier.md
@@ -1,13 +1,13 @@
 # `water_movement_efficiency_multiplier`
+:::infoRequires:
+Server Version 1.21+
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies water movement efficiency
-
-:::infoRequires:
-Server Version 1.21+
-:::
 # Effect Syntax
 ```yaml
 - id: water_movement_efficiency_multiplier

--- a/docs/effects/all-filters/at_war_with_victim.md
+++ b/docs/effects/all-filters/at_war_with_victim.md
@@ -1,10 +1,9 @@
 # `at_war_with_victim`
-
-Requires the player is in a declared war with the victim
-
 :::infoRequires:
 Lands
 :::
+
+Requires the player is in a declared war with the victim
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/battlepass_reward.md
+++ b/docs/effects/all-filters/battlepass_reward.md
@@ -1,10 +1,9 @@
 # `battlepass_reward`
-
-The list of battlepass rewards the effect should activate on
-
 :::infoRequires:
 xBattlepass
 :::
+
+The list of battlepass rewards the effect should activate on
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/battlepass_task.md
+++ b/docs/effects/all-filters/battlepass_task.md
@@ -1,10 +1,9 @@
 # `battlepass_task`
-
-The list of battlepass rewards the effect should activate on
-
 :::infoRequires:
 xBattlepass
 :::
+
+The list of battlepass rewards the effect should activate on
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/custom_crop_stage.md
+++ b/docs/effects/all-filters/custom_crop_stage.md
@@ -1,10 +1,9 @@
 # `custom_crop_stage`
-
-The list of crop stages the effect should activate on
-
 :::infoRequires:
 CustomCrops
 :::
+
+The list of crop stages the effect should activate on
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/custom_crop_type.md
+++ b/docs/effects/all-filters/custom_crop_type.md
@@ -1,10 +1,9 @@
 # `custom_crop_type`
-
-The list of crop types the effect should activate on
-
 :::infoRequires:
 CustomCrops
 :::
+
+The list of crop types the effect should activate on
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/custom_fish_type.md
+++ b/docs/effects/all-filters/custom_fish_type.md
@@ -1,10 +1,9 @@
 # `custom_fish_type`
-
-The list of fish types the effect should activate on
-
 :::infoRequires:
 CustomFishing
 :::
+
+The list of fish types the effect should activate on
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/envoy_type.md
+++ b/docs/effects/all-filters/envoy_type.md
@@ -1,10 +1,9 @@
 # `envoy_type`
-
-The list of envoy types that the effect should activate against
-
 :::infoRequires:
 AxEnvoy
 :::
+
+The list of envoy types that the effect should activate against
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/fertilizer_type.md
+++ b/docs/effects/all-filters/fertilizer_type.md
@@ -1,10 +1,9 @@
 # `fertilizer_type`
-
-The list of fertilizers the effect should activate on
-
 :::infoRequires:
 CustomCrops
 :::
+
+The list of fertilizers the effect should activate on
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/job.md
+++ b/docs/effects/all-filters/job.md
@@ -1,10 +1,9 @@
 # `job`
-
-Require a certain job
-
 :::infoRequires:
 EcoJobs
 :::
+
+Require a certain job
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/magic_type.md
+++ b/docs/effects/all-filters/magic_type.md
@@ -1,10 +1,9 @@
 # `magic_type`
-
-Require a certain magic type
-
 :::infoRequires:
 EcoSkills
 :::
+
+Require a certain magic type
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/npc.md
+++ b/docs/effects/all-filters/npc.md
@@ -1,10 +1,9 @@
 # `npc`
-
-Require a certain NPC
-
 :::infoRequires:
 Citizens || FancyNpcs
 :::
+
+Require a certain NPC
 # Filter Syntax
 
 **Citizens**

--- a/docs/effects/all-filters/pet.md
+++ b/docs/effects/all-filters/pet.md
@@ -1,10 +1,9 @@
 # `pet`
-
-Require a certain pet
-
 :::infoRequires:
 EcoPets
 :::
+
+Require a certain pet
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/quest.md
+++ b/docs/effects/all-filters/quest.md
@@ -1,10 +1,9 @@
 # `quest`
-
-Require a certain quest
-
 :::infoRequires:
 EcoQuests
 :::
+
+Require a certain quest
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/region.md
+++ b/docs/effects/all-filters/region.md
@@ -1,11 +1,9 @@
 # `region`
-
-Require a certain region
-
-
 :::infoRequires:
 WorldGuard
 :::
+
+Require a certain region
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/scroll.md
+++ b/docs/effects/all-filters/scroll.md
@@ -1,10 +1,9 @@
 # `scroll`
-
-Require a certain scroll
-
 :::infoRequires:
 EcoScrolls
 :::
+
+Require a certain scroll
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/shop_item.md
+++ b/docs/effects/all-filters/shop_item.md
@@ -1,10 +1,9 @@
 # `shop_item`
-
-Require a certain shop item
-
 :::infoRequires:
 EcoShop
 :::
+
+Require a certain shop item
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/skill.md
+++ b/docs/effects/all-filters/skill.md
@@ -1,10 +1,9 @@
 # `skill`
-
-Require a certain skill
-
 :::infoRequires:
 EcoSkills || McMMO
 :::
+
+Require a certain skill
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/task.md
+++ b/docs/effects/all-filters/task.md
@@ -1,10 +1,9 @@
 # `task`
-
-Require a certain task
-
 :::infoRequires:
 EcoQuests
 :::
+
+Require a certain task
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/town_role.md
+++ b/docs/effects/all-filters/town_role.md
@@ -1,10 +1,9 @@
 # `town_role`
-
-The list of town roles the effect should activate on
-
 :::infoRequires:
 HuskTowns
 :::
+
+The list of town roles the effect should activate on
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/vote_service.md
+++ b/docs/effects/all-filters/vote_service.md
@@ -1,11 +1,9 @@
 # `vote_service`
-
-The list of vote services that the effect should activate on
-
-
 :::infoRequires:
 Votifier
 :::
+
+The list of vote services that the effect should activate on
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/all-filters/watering_can_type.md
+++ b/docs/effects/all-filters/watering_can_type.md
@@ -1,10 +1,9 @@
 # `watering_can_type`
-
-The list of watering cans the effect should activate on
-
 :::infoRequires:
 CustomCrops
 :::
+
+The list of watering cans the effect should activate on
 # Filter Syntax
 ```yaml
 filters:

--- a/docs/effects/external-integrations/auraskills/conditions/has_mana.md
+++ b/docs/effects/external-integrations/auraskills/conditions/has_mana.md
@@ -1,10 +1,9 @@
 # `has_mana`
-
-Requires a player to have amount of mana
-
 :::infoRequires:
 AuraSkills
 :::
+
+Requires a player to have amount of mana
 # Example Config
 ```yaml
 - id: has_mana

--- a/docs/effects/external-integrations/auraskills/conditions/has_skill_level.md
+++ b/docs/effects/external-integrations/auraskills/conditions/has_skill_level.md
@@ -1,10 +1,9 @@
 # `has_skill_level`
-
-Requires a player to have a certain skill level
-
 :::infoRequires:
 EcoSkills || AuraSkills
 :::
+
+Requires a player to have a certain skill level
 # Example Config
 ```yaml
 - id: has_skill_level

--- a/docs/effects/external-integrations/auraskills/effects/add_stat.md
+++ b/docs/effects/external-integrations/auraskills/effects/add_stat.md
@@ -1,13 +1,13 @@
 # `add_stat`
+:::infoRequires:
+EcoSkills || AuraSkills
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Adds a value to a specific stat
-
-:::infoRequires:
-EcoSkills || AuraSkills
-:::
 # Example Config
 ```yaml
 - id: add_stat

--- a/docs/effects/external-integrations/auraskills/effects/skill_xp_multiplier.md
+++ b/docs/effects/external-integrations/auraskills/effects/skill_xp_multiplier.md
@@ -1,13 +1,13 @@
 # `skill_xp_multiplier`
+:::infoRequires:
+EcoSkills || AuraSkills
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies skill xp gain
-
-:::infoRequires:
-EcoSkills || AuraSkills
-:::
 # Example Config
 ```yaml
 - id: skill_xp_multiplier

--- a/docs/effects/external-integrations/axenvoy/filters/envoy_type.md
+++ b/docs/effects/external-integrations/axenvoy/filters/envoy_type.md
@@ -1,10 +1,9 @@
 # `envoy_type`
-
-The list of envoy types that the effect should activate against
-
 :::infoRequires:
 AxEnvoy
 :::
+
+The list of envoy types that the effect should activate against
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/citizens/filters/npc.md
+++ b/docs/effects/external-integrations/citizens/filters/npc.md
@@ -1,10 +1,9 @@
 # `npc`
-
-Require a certain NPC
-
 :::infoRequires:
 Citizens || FancyNpcs
 :::
+
+Require a certain NPC
 # Example Config
 
 **Citizens**

--- a/docs/effects/external-integrations/customcrops/conditions/is_season.md
+++ b/docs/effects/external-integrations/customcrops/conditions/is_season.md
@@ -1,10 +1,9 @@
 # `is_season`
-
-Requires it to be a certain season
-
 :::infoRequires:
 CustomCrops
 :::
+
+Requires it to be a certain season
 # Example Config
 ```yaml
 - id: is_season

--- a/docs/effects/external-integrations/customcrops/filters/custom_crop_stage.md
+++ b/docs/effects/external-integrations/customcrops/filters/custom_crop_stage.md
@@ -1,10 +1,9 @@
 # `custom_crop_stage`
-
-The list of crop stages the effect should activate on
-
 :::infoRequires:
 CustomCrops
 :::
+
+The list of crop stages the effect should activate on
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/customcrops/filters/custom_crop_type.md
+++ b/docs/effects/external-integrations/customcrops/filters/custom_crop_type.md
@@ -1,10 +1,9 @@
 # `custom_crop_type`
-
-The list of crop types the effect should activate on
-
 :::infoRequires:
 CustomCrops
 :::
+
+The list of crop types the effect should activate on
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/customcrops/filters/fertilizer_type.md
+++ b/docs/effects/external-integrations/customcrops/filters/fertilizer_type.md
@@ -1,10 +1,9 @@
 # `fertilizer_type`
-
-The list of fertilizers the effect should activate on
-
 :::infoRequires:
 CustomCrops
 :::
+
+The list of fertilizers the effect should activate on
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/customcrops/filters/watering_can_type.md
+++ b/docs/effects/external-integrations/customcrops/filters/watering_can_type.md
@@ -1,10 +1,9 @@
 # `watering_can_type`
-
-The list of watering cans the effect should activate on
-
 :::infoRequires:
 CustomCrops
 :::
+
+The list of watering cans the effect should activate on
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/customfishing/filters/custom_fish_type.md
+++ b/docs/effects/external-integrations/customfishing/filters/custom_fish_type.md
@@ -1,10 +1,9 @@
 # `custom_fish_type`
-
-The list of fish types the effect should activate on
-
 :::infoRequires:
 CustomFishing
 :::
+
+The list of fish types the effect should activate on
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/fancynpcs/filters/npc.md
+++ b/docs/effects/external-integrations/fancynpcs/filters/npc.md
@@ -1,10 +1,9 @@
 # `npc`
-
-Require a certain NPC
-
 :::infoRequires:
 Citizens || FancyNpcs
 :::
+
+Require a certain NPC
 # Example Config
 
 **Citizens**

--- a/docs/effects/external-integrations/flaremobcoins/effects/mob_coins_multiplier.md
+++ b/docs/effects/external-integrations/flaremobcoins/effects/mob_coins_multiplier.md
@@ -1,13 +1,13 @@
 # `mob_coins_multiplier`
+:::infoRequires:
+Flare Mobcoins
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies mob coin drops
-
-:::infoRequires:
-Flare Mobcoins
-:::
 # Example Config
 ```yaml
 - id: mob_coins_multiplier

--- a/docs/effects/external-integrations/huskclaims/conditions/in_own_claim.md
+++ b/docs/effects/external-integrations/huskclaims/conditions/in_own_claim.md
@@ -1,10 +1,9 @@
 # `in_own_claim`
-
-Requires the player to be in their own claim
-
 :::infoRequires:
 HuskClaims || HuskTowns || Lands
 :::
+
+Requires the player to be in their own claim
 # Example Config
 ```yaml
 - id: in_own_claim

--- a/docs/effects/external-integrations/husktowns/conditions/has_town_role.md
+++ b/docs/effects/external-integrations/husktowns/conditions/has_town_role.md
@@ -1,10 +1,9 @@
 # `has_town_role`
-
-Requires a player to have a certain role in a town
-
 :::infoRequires:
 HuskTowns
 :::
+
+Requires a player to have a certain role in a town
 # Example Config
 ```yaml
 - id: has_town_role

--- a/docs/effects/external-integrations/husktowns/conditions/in_own_claim.md
+++ b/docs/effects/external-integrations/husktowns/conditions/in_own_claim.md
@@ -1,10 +1,9 @@
 # `in_own_claim`
-
-Requires the player to be in their own claim
-
 :::infoRequires:
 HuskClaims || HuskTowns || Lands
 :::
+
+Requires the player to be in their own claim
 # Example Config
 ```yaml
 - id: in_own_claim

--- a/docs/effects/external-integrations/husktowns/filters/town_role.md
+++ b/docs/effects/external-integrations/husktowns/filters/town_role.md
@@ -1,10 +1,9 @@
 # `town_role`
-
-The list of town roles the effect should activate on
-
 :::infoRequires:
 HuskTowns
 :::
+
+The list of town roles the effect should activate on
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/jobs-reborn/effects/jobs_money_multiplier.md
+++ b/docs/effects/external-integrations/jobs-reborn/effects/jobs_money_multiplier.md
@@ -1,14 +1,13 @@
 # `jobs_money_multiplier`
+:::infoRequires:
+Jobs Reborn
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies money gain from jobs
-
-
-:::infoRequires:
-Jobs Reborn
-:::
 # Example Config
 ```yaml
 - id: jobs_money_multiplier

--- a/docs/effects/external-integrations/jobs-reborn/effects/jobs_xp_multiplier.md
+++ b/docs/effects/external-integrations/jobs-reborn/effects/jobs_xp_multiplier.md
@@ -1,14 +1,13 @@
 # `jobs_xp_multiplier`
+:::infoRequires:
+Jobs Reborn
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies xp gain from jobs
-
-
-:::infoRequires:
-Jobs Reborn
-:::
 # Example Config
 ```yaml
 - id: jobs_xp_multiplier

--- a/docs/effects/external-integrations/lands/conditions/has_lands_role.md
+++ b/docs/effects/external-integrations/lands/conditions/has_lands_role.md
@@ -1,10 +1,9 @@
 # `has_lands_role`
-
-Requires a player to have a certain role in the Land
-
 :::infoRequires:
 Lands
 :::
+
+Requires a player to have a certain role in the Land
 # Example Config
 ```yaml
 - id: has_lands_role

--- a/docs/effects/external-integrations/lands/conditions/in_own_claim.md
+++ b/docs/effects/external-integrations/lands/conditions/in_own_claim.md
@@ -1,10 +1,9 @@
 # `in_own_claim`
-
-Requires the player to be in their own claim
-
 :::infoRequires:
 HuskClaims || HuskTowns || Lands
 :::
+
+Requires the player to be in their own claim
 # Example Config
 ```yaml
 - id: in_own_claim

--- a/docs/effects/external-integrations/lands/conditions/in_trusted_claim.md
+++ b/docs/effects/external-integrations/lands/conditions/in_trusted_claim.md
@@ -1,10 +1,9 @@
 # `in_trusted_claim`
-
-Requires the player to be in a claim they're trusted in
-
 :::infoRequires:
 Lands
 :::
+
+Requires the player to be in a claim they're trusted in
 # Example Config
 ```yaml
 - id: in_trusted_claim

--- a/docs/effects/external-integrations/lands/conditions/lands_balance_above.md
+++ b/docs/effects/external-integrations/lands/conditions/lands_balance_above.md
@@ -1,10 +1,9 @@
 # `lands_balance_above`
-
-Requires the Land's bank balance to be above a value
-
 :::infoRequires:
 Lands
 :::
+
+Requires the Land's bank balance to be above a value
 # Example Config
 ```yaml
 - id: lands_balance_above

--- a/docs/effects/external-integrations/lands/conditions/lands_balance_below.md
+++ b/docs/effects/external-integrations/lands/conditions/lands_balance_below.md
@@ -1,10 +1,9 @@
 # `lands_balance_below`
-
-Requires the Land's bank balance to be below a value
-
 :::infoRequires:
 Lands
 :::
+
+Requires the Land's bank balance to be below a value
 # Example Config
 ```yaml
 - id: lands_balance_below

--- a/docs/effects/external-integrations/lands/conditions/lands_balance_equal.md
+++ b/docs/effects/external-integrations/lands/conditions/lands_balance_equal.md
@@ -1,10 +1,9 @@
 # `lands_balance_equal`
-
-Requires the Land's bank balance to be equal to a value
-
 :::infoRequires:
 Lands
 :::
+
+Requires the Land's bank balance to be equal to a value
 # Example Config
 ```yaml
 - id: lands_balance_equal

--- a/docs/effects/external-integrations/lands/effects/give_lands_balance.md
+++ b/docs/effects/external-integrations/lands/effects/give_lands_balance.md
@@ -1,13 +1,13 @@
 # `give_lands_balance`
+:::infoRequires:
+Lands
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Give money to a Land's bank balance
-
-:::infoRequires:
-Lands
-:::
 # Example Config
 
 ```yaml

--- a/docs/effects/external-integrations/lands/effects/set_lands_balance.md
+++ b/docs/effects/external-integrations/lands/effects/set_lands_balance.md
@@ -1,13 +1,13 @@
 # `set_lands_balance`
+:::infoRequires:
+Lands
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Set the Land bank's balance
-
-:::infoRequires:
-Lands
-:::
 # Example Config
 
 ```yaml

--- a/docs/effects/external-integrations/lands/filters/at_war_with_victim.md
+++ b/docs/effects/external-integrations/lands/filters/at_war_with_victim.md
@@ -1,10 +1,9 @@
 # `at_war_with_victim`
-
-Requires the player is in a declared war with the victim
-
 :::infoRequires:
 Lands
 :::
+
+Requires the player is in a declared war with the victim
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/mcmmo/conditions/has_mcmmo_level.md
+++ b/docs/effects/external-integrations/mcmmo/conditions/has_mcmmo_level.md
@@ -1,10 +1,9 @@
 # `has_mcmmo_level`
-
-Requires a player to have a certain McMMO skill level
-
 :::infoRequires:
 McMMO
 :::
+
+Requires a player to have a certain McMMO skill level
 # Example Config
 ```yaml
 - id: has_mcmmo_level

--- a/docs/effects/external-integrations/mcmmo/conditions/mcmmo_ability_on_cooldown.md
+++ b/docs/effects/external-integrations/mcmmo/conditions/mcmmo_ability_on_cooldown.md
@@ -1,10 +1,9 @@
 # `mcmmo_ability_on_cooldown`
-
-Requires an McMMO ability to be on cooldown
-
 :::infoRequires:
 McMMO
 :::
+
+Requires an McMMO ability to be on cooldown
 # Example Config
 ```yaml
 - id: mcmmo_ability_on_cooldown

--- a/docs/effects/external-integrations/mcmmo/effects/give_mcmmo_xp.md
+++ b/docs/effects/external-integrations/mcmmo/effects/give_mcmmo_xp.md
@@ -1,13 +1,13 @@
 # `give_mcmmo_xp`
+:::infoRequires:
+McMMO
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a certain skill
-
-:::infoRequires:
-McMMO
-:::
 # Example Config
 ```yaml
 - id: give_mcmmo_xp

--- a/docs/effects/external-integrations/mcmmo/effects/mcmmo_xp_multiplier.md
+++ b/docs/effects/external-integrations/mcmmo/effects/mcmmo_xp_multiplier.md
@@ -1,13 +1,13 @@
 # `mcmmo_xp_multiplier`
+:::infoRequires:
+McMMO
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies mcMMO skill xp gain
-
-:::infoRequires:
-McMMO
-:::
 # Example Config
 ```yaml
 - id: mcmmo_xp_multiplier

--- a/docs/effects/external-integrations/mcmmo/filters/mcmmo_ability.md
+++ b/docs/effects/external-integrations/mcmmo/filters/mcmmo_ability.md
@@ -1,10 +1,9 @@
 # `mcmmo_ability`
-
-The list of [entities](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html) that the effect should activate against
-
 :::infoRequires:
 Lands
 :::
+
+The list of [entities](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html) that the effect should activate against
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/mcmmo/filters/skill.md
+++ b/docs/effects/external-integrations/mcmmo/filters/skill.md
@@ -1,10 +1,9 @@
 # `skill`
-
-Require a certain skill
-
 :::infoRequires:
 EcoSkills || McMMO
 :::
+
+Require a certain skill
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/modelengine/effects/play_animation.md
+++ b/docs/effects/external-integrations/modelengine/effects/play_animation.md
@@ -1,14 +1,13 @@
 # `play_animation`
+:::infoRequires:
+Model Engine
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Plays a Model Engine animation (The entity must have a custom model active)
-
-
-:::infoRequires:
-Model Engine
-:::
 # Example Config
 ```yaml
 - id: play_animation

--- a/docs/effects/external-integrations/paper/conditions/in_bubble.md
+++ b/docs/effects/external-integrations/paper/conditions/in_bubble.md
@@ -1,10 +1,9 @@
 # `in_bubble`
-
-Requires a player to be in a bubble column
-
 :::infoRequires:
 Paper
 :::
+
+Requires a player to be in a bubble column
 # Example Config
 ```yaml
 - id: in_bubble

--- a/docs/effects/external-integrations/paper/conditions/in_lava.md
+++ b/docs/effects/external-integrations/paper/conditions/in_lava.md
@@ -1,10 +1,9 @@
 # `in_lava`
-
-Requires a player to be in lava
-
 :::infoRequires:
 Paper
 :::
+
+Requires a player to be in lava
 # Example Config
 ```yaml
 - id: in_lava

--- a/docs/effects/external-integrations/paper/conditions/in_rain.md
+++ b/docs/effects/external-integrations/paper/conditions/in_rain.md
@@ -1,10 +1,9 @@
 # `in_rain`
-
-Requires a player to be in rain
-
 :::infoRequires:
 Paper
 :::
+
+Requires a player to be in rain
 # Example Config
 ```yaml
 - id: in_rain

--- a/docs/effects/external-integrations/paper/effects/drop_pickup_item.md
+++ b/docs/effects/external-integrations/paper/effects/drop_pickup_item.md
@@ -1,13 +1,13 @@
 # `drop_pickup_item`
+:::infoRequires:
+Paper
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Drops an item that runs a chain on pickup
-
-:::infoRequires:
-Paper
-:::
 # Example Config
 
 ```yaml

--- a/docs/effects/external-integrations/paper/effects/send_minimessage.md
+++ b/docs/effects/external-integrations/paper/effects/send_minimessage.md
@@ -1,13 +1,13 @@
 # `send_minimessage`
+:::infoRequires:
+Paper
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Sends the player a minimessage message, supports clickable components, etc.
-
-:::infoRequires:
-Paper
-:::
 # Example Config
 ```yaml
 - id: send_minimessage

--- a/docs/effects/external-integrations/tab/conditions/has_boss_bar_visible.md
+++ b/docs/effects/external-integrations/tab/conditions/has_boss_bar_visible.md
@@ -1,10 +1,9 @@
 # `has_boss_bar_visible`
-
-Requires a player to have the TAB boss bar shown to them
-
 :::infoRequires:
 TAB
 :::
+
+Requires a player to have the TAB boss bar shown to them
 # Example Config
 ```yaml
 - id: has_boss_bar_visible

--- a/docs/effects/external-integrations/tab/conditions/has_scoreboard_visible.md
+++ b/docs/effects/external-integrations/tab/conditions/has_scoreboard_visible.md
@@ -1,10 +1,9 @@
 # `has_scoreboard_visible`
-
-Requires a player to have the TAB scoreboard shown to them
-
 :::infoRequires:
 TAB
 :::
+
+Requires a player to have the TAB scoreboard shown to them
 # Example Config
 ```yaml
 - id: has_scoreboard_visible

--- a/docs/effects/external-integrations/ultimatemobcoins/effects/mob_coins_chance_multiplier.md
+++ b/docs/effects/external-integrations/ultimatemobcoins/effects/mob_coins_chance_multiplier.md
@@ -1,14 +1,13 @@
 # `mob_coins_chance_multiplier`
+:::infoRequires:
+UltimateMobCoins
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies the chance of mobcoins being dropped
-
-
-:::infoRequires:
-UltimateMobCoins
-:::
 # Example Config
 ```yaml
 - id: mob_coins_chance_multiplier

--- a/docs/effects/external-integrations/ultimatemobcoins/effects/mob_coins_drop_multiplier.md
+++ b/docs/effects/external-integrations/ultimatemobcoins/effects/mob_coins_drop_multiplier.md
@@ -1,14 +1,13 @@
 # `mob_coins_drop_multiplier`
+:::infoRequires:
+UltimateMobCoins
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies the mobcoins dropped
-
-
-:::infoRequires:
-UltimateMobCoins
-:::
 # Example Config
 ```yaml
 - id: mob_coins_drop_multiplier

--- a/docs/effects/external-integrations/vault/effects/give_permission.md
+++ b/docs/effects/external-integrations/vault/effects/give_permission.md
@@ -1,13 +1,13 @@
 # `give_permission`
+:::infoRequires:
+Vault
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Gives a permission while active
-
-:::infoRequires:
-Vault
-:::
 # Example Config
 ```yaml
 - id: give_permission

--- a/docs/effects/external-integrations/votifier/filters/vote_service.md
+++ b/docs/effects/external-integrations/votifier/filters/vote_service.md
@@ -1,11 +1,9 @@
 # `vote_service`
-
-The list of vote services that the effect should activate on
-
-
 :::infoRequires:
 Votifier
 :::
+
+The list of vote services that the effect should activate on
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/worldguard/conditions/in_region.md
+++ b/docs/effects/external-integrations/worldguard/conditions/in_region.md
@@ -1,11 +1,9 @@
 # `in_region`
-
-Requires a player to be in a certain region
-
-
 :::infoRequires:
 WorldGuard
 :::
+
+Requires a player to be in a certain region
 # Example Config
 ```yaml
 - id: in_region

--- a/docs/effects/external-integrations/worldguard/filters/region.md
+++ b/docs/effects/external-integrations/worldguard/filters/region.md
@@ -1,11 +1,9 @@
 # `region`
-
-Require a certain region
-
-
 :::infoRequires:
 WorldGuard
 :::
+
+Require a certain region
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/xbattlepass/conditions/has_battlepass_tier.md
+++ b/docs/effects/external-integrations/xbattlepass/conditions/has_battlepass_tier.md
@@ -1,10 +1,9 @@
 # `has_battlepass_tier`
-
-Requires a player to have a certain battlepass tier
-
 :::infoRequires:
 xBattlepass
 :::
+
+Requires a player to have a certain battlepass tier
 # Example Config
 ```yaml
 - id: has_battlepass_tier

--- a/docs/effects/external-integrations/xbattlepass/conditions/has_premium_battlepass.md
+++ b/docs/effects/external-integrations/xbattlepass/conditions/has_premium_battlepass.md
@@ -1,10 +1,9 @@
 # `has_premium_battlepass`
-
-Requires a player to have the premium battlepass
-
 :::infoRequires:
 xBattlepass
 :::
+
+Requires a player to have the premium battlepass
 # Example Config
 ```yaml
 - id: has_premium_battlepass

--- a/docs/effects/external-integrations/xbattlepass/effects/battlepass_task_xp_multiplier.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/battlepass_task_xp_multiplier.md
@@ -1,13 +1,13 @@
 # `battlepass_task_xp_multiplier`
+:::infoRequires:
+xBattlepass
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies incoming battlepass task xp gain
-
-:::infoRequires:
-xBattlepass
-:::
 # Example Config
 ```yaml
 - id: battlepass_task_xp_multiplier

--- a/docs/effects/external-integrations/xbattlepass/effects/battlepass_xp_multiplier.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/battlepass_xp_multiplier.md
@@ -1,13 +1,13 @@
 # `battlepass_xp_multiplier`
+:::infoRequires:
+xBattlepass
+:::
+
 :::dangerPermanent Effect
 This effect is permanent and does not require a trigger.
 :::
 
 Multiplies incoming battlepass xp gain
-
-:::infoRequires:
-xBattlepass
-:::
 # Example Config
 ```yaml
 - id: battlepassxp_multiplier

--- a/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_task_xp.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_task_xp.md
@@ -1,13 +1,13 @@
 # `give_battlepass_task_xp`
+:::infoRequires:
+xBattlepass
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Gives experience points for a task in a quest, excluding multipliers.
-
-:::infoRequires:
-xBattlepass
-:::
 # Example Config
 ```yaml
 - id: give_battlepass_task_xp

--- a/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_tier.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_tier.md
@@ -1,13 +1,13 @@
 # `give_battlepass_tier`
+:::infoRequires:
+xBattlepass
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Give battlepass tiers to the player.
-
-:::infoRequires:
-xBattlepass
-:::
 # Example Config
 ```yaml
 - id: give_battlepass_tier

--- a/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_xp.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/give_battlepass_xp.md
@@ -1,13 +1,13 @@
 # `give_battlepass_xp`
+:::infoRequires:
+xBattlepass
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Give battlepass experience points
-
-:::infoRequires:
-xBattlepass
-:::
 # Example Config
 ```yaml
 - id: give_battlepass_xp

--- a/docs/effects/external-integrations/xbattlepass/effects/set_battlepass_tier.md
+++ b/docs/effects/external-integrations/xbattlepass/effects/set_battlepass_tier.md
@@ -1,13 +1,13 @@
 # `set_battlepass_tier`
+:::infoRequires:
+xBattlepass
+:::
+
 :::dangerTriggered Effect
 This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
 :::
 
 Set the player's battlepass tier
-
-:::infoRequires:
-xBattlepass
-:::
 # Example Config
 ```yaml
 - id: set_battlepass_tier

--- a/docs/effects/external-integrations/xbattlepass/filters/battlepass_reward.md
+++ b/docs/effects/external-integrations/xbattlepass/filters/battlepass_reward.md
@@ -1,10 +1,9 @@
 # `battlepass_reward`
-
-The list of battlepass rewards the effect should activate on
-
 :::infoRequires:
 xBattlepass
 :::
+
+The list of battlepass rewards the effect should activate on
 # Example Config
 ```yaml
 filters:

--- a/docs/effects/external-integrations/xbattlepass/filters/battlepass_task.md
+++ b/docs/effects/external-integrations/xbattlepass/filters/battlepass_task.md
@@ -1,10 +1,9 @@
 # `battlepass_task`
-
-The list of battlepass rewards the effect should activate on
-
 :::infoRequires:
 xBattlepass
 :::
+
+The list of battlepass rewards the effect should activate on
 # Example Config
 ```yaml
 filters:

--- a/docs/reforges/reforges-effects/conditions/has_reforge.md
+++ b/docs/reforges/reforges-effects/conditions/has_reforge.md
@@ -1,11 +1,9 @@
 # `has_reforge`
-
-Requires a player to have a certain reforge active
-
-
 :::infoRequires:
 Reforges
 :::
+
+Requires a player to have a certain reforge active
 # Condition Syntax
 ```yaml
 - id: has_reforge

--- a/docs/talismans/talismans-effects/conditions/has_talisman.md
+++ b/docs/talismans/talismans-effects/conditions/has_talisman.md
@@ -1,11 +1,9 @@
 # `has_talisman`
-
-Requires a player to have a certain talisman active
-
-
 :::infoRequires:
 Talismans
 :::
+
+Requires a player to have a certain talisman active
 # Condition Syntax
 ```yaml
 - id: has_talisman


### PR DESCRIPTION
Standardized documentation by placing the 'Requires' info box before the main description in all plugin effect, condition, and filter markdown files. This improves consistency and readability across the documentation.