### PR TITLE
Standardize trigger documentation and placeholders

### DIFF
--- a/docs/ecoenchants/ecoenchants-effects/all-triggers.md
+++ b/docs/ecoenchants/ecoenchants-effects/all-triggers.md
@@ -2,12 +2,17 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders), and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID               | Description                                                                                   | Value       | Alt-Value |
-| ---------------- | --------------------------------------------------------------------------------------------- | ----------- | --------- |
-| `enchant_<type>` | Triggered when enchanting an item with a certain type of enchantment **Requires EcoEnchants** | The xp cost | -         |
+| ID               | Description                                                          | Value(s)             |
+| ---------------- | -------------------------------------------------------------------- | -------------------- |
+| `enchant_<type>` | Triggered when enchanting an item with a certain type of enchantment | `value: The xp cost` |
 

--- a/docs/ecojobs/ecojobs-effects/all-triggers.md
+++ b/docs/ecojobs/ecojobs-effects/all-triggers.md
@@ -2,15 +2,19 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders), and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID             | Description                                                       | Value                 | Alt-Value |
-| -------------- | ----------------------------------------------------------------- | --------------------- | --------- |
-| `gain_job_xp`  | Triggered when gaining job experience points **Requires EcoJobs** | The experience gained | -         |
-| `join_job`     | Triggered when joining a job **Requires EcoJobs**                 | The job level         | -         |
-| `leave_job`    | Triggered when leaving a job **Requires EcoJobs**                 | The job level         | -         |
-| `level_up_job` | Triggered when levelling up a job **Requires EcoJobs**            | The new level         | -         |
-
+| ID             | Description                                  | Value(s)                       |
+| -------------- | -------------------------------------------- | ------------------------------ |
+| `gain_job_xp`  | Triggered when gaining job experience points | `value: The experience gained` |
+| `join_job`     | Triggered when joining a job                 | `value: The job level`         |
+| `leave_job`    | Triggered when leaving a job                 | `value: The job level`         |
+| `level_up_job` | Triggered when levelling up a job            | `value: The new level`         |

--- a/docs/ecopets/ecopets-effects/all-triggers.md
+++ b/docs/ecopets/ecopets-effects/all-triggers.md
@@ -2,13 +2,17 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders), and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID             | Description                                                       | Value                 | Alt-Value |
-| -------------- | ----------------------------------------------------------------- | --------------------- | --------- |
-| `gain_pet_xp`  | Triggered when gaining pet experience points **Requires EcoPets** | The experience gained | -         |
-| `level_up_pet` | Triggered when levelling up a pet **Requires EcoPets**            | The new level         | -         |
-
+| ID             | Description                                  | Value(s)                       |
+| -------------- | -------------------------------------------- | ------------------------------ |
+| `gain_pet_xp`  | Triggered when gaining pet experience points | `value: The experience gained` |
+| `level_up_pet` | Triggered when levelling up a pet            | `value: The new level`         |

--- a/docs/ecoquests/ecoquests-effects/all-triggers.md
+++ b/docs/ecoquests/ecoquests-effects/all-triggers.md
@@ -2,14 +2,19 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders), and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID               | Description                                              | Value                 | Alt-Value |
-| ---------------- | -------------------------------------------------------- | --------------------- | --------- |
-| `complete_quest` | Triggered when completing a quest **Requires EcoQuests** | 1                     | -         |
-| `complete_task`  | Triggered when completing a task **Requires EcoQuests**  | 1                     | -         |
-| `gain_task_xp`   | Triggered when gaining task XP **Requires EcoQuests**    | The experience gained | -         |
-| `start_quest`    | Triggered when starting a quest **Requires EcoQuests**   | 1                     | -         |
+| ID               | Description                       | Value(s)                       |
+| ---------------- | --------------------------------- | ------------------------------ |
+| `complete_task`  | Triggered when completing a task  | `value: 1`                     |
+| `complete_quest` | Triggered when completing a quest | `value: 1`                     |
+| `gain_task_xp`   | Triggered when gaining task XP    | `value: The experience gained` |
+| `start_quest`    | Triggered when starting a quest   | `value: 1`                     |

--- a/docs/ecoscrolls/ecoscrolls-effects/all-triggers.md
+++ b/docs/ecoscrolls/ecoscrolls-effects/all-triggers.md
@@ -1,13 +1,18 @@
 ---
-title: Triggers
+title: EcoScrolls Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders), and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID             | Description                                                            | Value | Alt-Value |
-| -------------- | ---------------------------------------------------------------------- | ----- | --------- |
-| `inscribe`     | Triggered when inscribing a scroll **Requires EcoScrolls**             | 1     | -         |
-| `try_inscribe` | Triggered when attempting to inscribe a scroll **Requires EcoScrolls** | 1     | -         |
+| ID             | Description                                    | Value(s)   |
+| -------------- | ---------------------------------------------- | ---------- |
+| `inscribe`     | Triggered when inscribing a scroll             | `value: 1` |
+| `try_inscribe` | Triggered when attempting to inscribe a scroll | `value: 1` |

--- a/docs/ecoshop/ecoshop-effects/all-triggers.md
+++ b/docs/ecoshop/ecoshop-effects/all-triggers.md
@@ -2,12 +2,17 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders), and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID          | Description                                                   | Value     | Alt-Value |
-| ----------- | ------------------------------------------------------------- | --------- | --------- |
-| `buy_item`  | Triggered when buying an item in a shop **Requires EcoShop**  | The price | -         |
-| `sell_item` | Triggered when selling an item in a shop **Requires EcoShop** | The price | -         |
+| ID          | Description                              | Value              |
+| ----------- | ---------------------------------------- | ------------------ |
+| `buy_item`  | Triggered when buying an item in a shop  | `value: The price` |
+| `sell_item` | Triggered when selling an item in a shop | `value: The price` |

--- a/docs/ecoskills/ecoskills-effects/all-triggers.md
+++ b/docs/ecoskills/ecoskills-effects/all-triggers.md
@@ -3,12 +3,18 @@ title: Triggers
 sidebar_position: 4
 ---
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders), and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-| ID               | Description                                                           | Value                 | Alt-Value |
-| ---------------- | --------------------------------------------------------------------- | --------------------- | --------- |
-| `gain_skill_xp`  | Triggered when gaining skill experience points **Requires EcoSkills** | The experience gained | -         |
-| `level_up_skill` | Triggered when levelling up **Requires EcoSkills**                    | The new level         | -         |
-| `regen_magic`    | Triggered when regenerating magic **Requires EcoSkills**              | 1                     | -         |
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
+
+| ID               | Description                                    | Value(s)                       |
+| ---------------- | ---------------------------------------------- | ------------------------------ |
+| `gain_skill_xp`  | Triggered when gaining skill experience points | `value: The experience gained` |
+| `level_up_skill` | Triggered when levelling up                    | `value: The new level`         |
+| `regen_magic`    | Triggered when regenerating magic              | `value: 1`                     |

--- a/docs/effects/all-triggers.md
+++ b/docs/effects/all-triggers.md
@@ -1,163 +1,178 @@
 ---
-title: "All Triggers"
+title: All Triggers
 sidebar_position: 7
+tags:
+  - triggers
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders), and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Internal Triggers
 
-| ID                              | Description                                                                                                       | Value                                         | Alt-Value       |
-| ------------------------------- |-------------------------------------------------------------------------------------------------------------------| --------------------------------------------- | --------------- |
-| `alt_click`                     | Triggered when using Right Click on most items, Left Click on those that have a default right click functionality | 1                                             | -               |
-| `beacon_effect`                 | Triggered when a player gains effects from a beacon **Requires Paper**                                            | 1                                             | -               |
-| `bite`                          | Triggered when a fish bites on your rod                                                                           | 1                                             | -               |
-| `block_item_drop`               | Triggered when a mined block drops loot                                                                           | The amount of items dropped                   | -               |
-| `bonemeal_crop`                 | Triggered when using bonemeal on a crop **Supports CustomCrops**                                                  | 1                                             | -               |
-| `bow_attack`                    | Triggered when shooting an entity with a bow and arrow (or crossbow)                                              | The damage dealt                              | -               |
-| `breed`                         | Triggered when breeding entities together                                                                         | The experience received                       | -               |
-| `brew`                          | Triggered when brewing a potion in a brewing stand                                                                | 1                                             | -               |
-| `brew_ingredient`               | Same as `brew`, but passes the ingredient as the item                                                             | 1                                             | -               |
-| `buy_item`                      | Triggered when buying an item in a shop **Requires EcoShop**                                                      | The price                                     | -               |
-| `cast_rod`                      | Triggered when casting a fishing line                                                                             | 1                                             | -               |
-| `catch_entity`                  | Triggered when hooking onto an entity with a fishing rod                                                          | 1                                             | -               |
-| `catch_fish`                    | Triggered when catching a fish                                                                                    | The experience dropped                        | -               |
-| `catch_fish_fail`               | Triggered when failing to catch a fish                                                                            | 1                                             | -               |
-| `change_armor`                  | Triggered when changing armor                                                                                     | 1                                             | -               |
-| `change_chunk`                  | Triggered when changing chunk                                                                                     | 1                                             | -               |
-| `change_town_role`              | Triggered when changing town role **Requires HuskTowns**                                                          | 1                                             | -               |
-| `change_world`                  | Triggered when changing world                                                                                     | 1                                             | -               |
-| `claim`                         | Triggered when claiming an area **Requires HuskTowns \|\|   HuskClaims \|\| Lands**                               | 1                                             | -               |
-| `claim_battlepass_reward`       | Triggered when claiming a battlepass reward **Requires xBattlepass**                                              | 1                                             | -               |
-| `click_block`                   | Triggered when right-clicking on a block                                                                          | 1                                             | -               |
-| `click_entity`                  | Triggered when right-clicking on an entity                                                                        | 1                                             | -               |
-| `collect_envoy`                 | Triggered when collecting an envoy crate **Requires AxEnvoy**                                                     | 1                                             | -               |
-| `complete_advancement`          | Triggered when completing an advancement                                                                          | 1                                             | -               |
-| `complete_battlepass_task`      | Triggered when completing a battlepass task **Requires xBattlepass**                                              | 1                                             | -               |
-| `complete_quest`                | Triggered when completing a quest **Requires EcoQuests**                                                          | 1                                             | -               |
-| `complete_task`                 | Triggered when completing a task **Requires EcoQuests**                                                           | 1                                             | -               |
-| `consume`                       | Triggered on item consumption                                                                                     | 1                                             | -               |
-| `craft`                         | Triggered when crafting an item                                                                                   | The amount of items crafted                   | -               |
-| `create_town`                   | Triggered when creating a Town **Requires HuskTowns**                                                             | 1                                             | -               |
-| `damage_item`                   | Triggered when damaging an item                                                                                   | The damage                                    | -               |
-| `death`                         | Triggered on death from any sources                                                                               | 1                                             | -               |
-| `deploy_elytra`                 | Triggered when the player starts elytra gliding                                                                   | 1                                             | -               |
-| `disable`                       | Triggered when an item / enchant / etc disables                                                                   | 1                                             | -               |
-| `disband_town`                  | Triggered when disbanding a Town **Requires HuskTowns**                                                           | 1                                             | -               |
-| `drop_item`                     | Triggered when dropping an item                                                                                   | The amount of items                           | -               |
-| `elytra_boost`                  | Triggered when a player boosts an elytra **Requires Paper**                                                       | 1                                             | -               |
-| `empty_bucket`                  | Triggered when emptying a bucket                                                                                  | 1                                             | -               |
-| `enable`                        | Triggered when an item / enchant / etc enables                                                                    | 1                                             | -               |
-| `enchant_<type>`                | Triggered when enchanting an item with a certain type of enchantment **Requires EcoEnchants**                     | The xp cost                                   | -               |
-| `enchant_item`                  | Triggered when enchanting an item                                                                                 | The xp cost                                   | -               |
-| `enter_bed`                     | Triggered when entering a bed                                                                                     | 1                                             | -               |
-| `enter_claim`                   | Triggered when entering a claimed area **Requires HuskTowns \|\| HuskClaims**                                     | 1                                             | -               |
-| `enter_region`                  | Triggered when entering a region **Requires WorldGuard**                                                          | 1                                             | -               |
-| `entity_break_door`             | Triggered when an entity breaks a door                                                                            | 1                                             | -               |
-| `entity_catch_fire_from_block`  | Triggered when an entity catches fire from a block                                                                | 1                                             | -               |
-| `entity_catch_fire_from_entity` | Triggered when an entity catches fire from an entity                                                              | 1                                             | -               |
-| `entity_damage`                 | Triggered when an entity takes damage                                                                             | The damage taken                              | -               |
-| `entity_damage_by_entity`       | Triggered when an entity takes damage from another entity                                                         | The damage taken                              | -               |
-| `entity_death`                  | Triggered when an entity dies                                                                                     | 1                                             | -               |
-| `entity_item_drop`              | Triggered when a killed entity drops loot                                                                         | The amount of items dropped                   | -               |
-| `entity_spawn`                  | Triggered when an entity spawns                                                                                   | 1                                             | -               |
-| `entity_target`                 | Triggered when an entity targets another entity                                                                   | 1                                             | -               |
-| `entity_teleport`               | Triggered when an entity teleports                                                                                | 1                                             | -               |
-| `exit_claim`                    | Triggered when exiting a claimed area **Requires HuskTowns \|\|   HuskClaims \|\| Lands**                         | 1                                             | -               |
-| `fall_damage`                   | Triggered when taking fall damage                                                                                 | The damage taken                              | -               |
-| `fill_bucket`                   | Triggered when filling a bucket                                                                                   | 1                                             | -               |
-| `gain_battlepass_xp`            | Triggered when gaining battlepass XP **Requires xBattlepass**                                                     | The experience gained                         | -               |
-| `gain_hunger`                   | Triggered when gaining hunger points                                                                              | The hunger gained                             | -               |
-| `gain_job_xp`                   | Triggered when gaining job experience points **Requires EcoJobs**                                                 | The experience gained                         | -               |
-| `gain_mcmmo_xp`                 | Triggered when gaining McMMO xp **Requires McMMO**                                                                | The xp gained                                 | -               |
-| `gain_pet_xp`                   | Triggered when gaining pet experience points **Requires EcoPets**                                                 | The experience gained                         | -               |
-| `gain_skill_xp`                 | Triggered when gaining skill experience points **Requires EcoSkills**                                             | The experience gained                         | -               |
-| `gain_task_xp`                  | Triggered when gaining task XP **Requires EcoQuests**                                                             | The experience gained                         | -               |
-| `gain_xp`                       | Triggered when gaining experience points                                                                          | The xp gained                                 | -               |
-| `global_static_%interval%`      | Run every x ticks for the server, eg `global_static_20` would run every second                                    | 1                                             | -               |
-| `harvest_custom_crop`           | Triggered when harvesting a custom crop **Requires CustomCrops**                                                  | 1                                             | -               |
-| `headshot`                      | Triggered when hitting an enemy with a projectile in the head                                                     | The damage dealt                              | -               |
-| `heal`                          | Triggered when regaining health                                                                                   | The health regained                           | -               |
-| `hold_item`                     | Triggered when changing your held item                                                                            | 1                                             | -               |
-| `hook_in_ground`                | Triggered when a fishing rod hook hits the ground                                                                 | 1                                             | -               |
-| `inscribe`                      | Triggered when inscribing a scroll **Requires EcoScrolls**                                                        | 1                                             | -               |
-| `item_break`                    | Triggered when breaking any item in your inventory (durability)                                                   | 1                                             | -               |
-| `jobs_level_up`                 | Triggered when levelling up a job **Requires Jobs Reborn**                                                        | The new level                                 | -               |
-| `join`                          | Triggered when joining the server                                                                                 | 1                                             | -               |
-| `join_job`                      | Triggered when joining a job **Requires EcoJobs**                                                                 | The job level                                 | -               |
-| `join_land`                     | Triggered when joining a Town                                                                                     | 1                                             | -               |
-| `join_town`                     | Triggered when joining a Town **Requires HuskTowns**                                                              | 1                                             | -               |
-| `jump`                          | Triggered when Jumping (pressing space)                                                                           | 1                                             | -               |
-| `kill`                          | Triggered when a player kills a player or entity                                                                  | The victim's max health                       | -               |
-| `lands_bank_deposit`            | Triggered when depositing into the Lands bank                                                                     | The value deposited                           | The new balance |
-| `lands_bank_withdraw`           | Triggered when withdrawing from the Lands bank                                                                    | The value withdrawn                           | The new balance |
-| `lands_spawn_teleport`          | Triggered when teleporting to Lands spawn                                                                         | 1                                             | -               |
-| `leash_entity`                  | Triggered when leashing an entity                                                                                 | 1                                             | -               |
-| `leave`                         | Triggered when leaving the server                                                                                 | 1                                             | -               |
-| `leave_bed`                     | Triggered when leaving a bed                                                                                      | 1                                             | -               |
-| `leave_job`                     | Triggered when leaving a job **Requires EcoJobs**                                                                 | The job level                                 | -               |
-| `leave_land`                    | Triggered when leaving a Town                                                                                     | 1                                             | -               |
-| `leave_region`                  | Triggered when leaving a region **Requires WorldGuard**                                                           | 1                                             | -               |
-| `leave_town`                    | Triggered when leaving a Town **Requires HuskTowns**                                                              | 1                                             | -               |
-| `left_click_npc`                | Triggered when left-clicking an NPC **Requires Citizens \|\| FancyNpcs**                                          | 1                                             | -               |
-| `level_down_mcmmo`              | Triggered when levelling down McMMO skill **Requires McMMO**                                                      | The new level                                 | -               |
-| `level_up_item`                 | Triggered when levelling up an item                                                                               | The new item level                            | -               |
-| `level_up_job`                  | Triggered when levelling up a job **Requires EcoJobs**                                                            | The new level                                 | -               |
-| `level_up_mcmmo`                | Triggered when levelling up McMMO skill **Requires McMMO**                                                        | The new level                                 | -               |
-| `level_up_pet`                  | Triggered when levelling up a pet **Requires EcoPets**                                                            | The new level                                 | -               |
-| `level_up_skill`                | Triggered when levelling up **Requires EcoSkills**                                                                | The new level                                 | -               |
-| `level_up_xp`                   | Triggered when levelling up XP                                                                                    | The new level                                 | -               |
-| `lose_hunger`                   | Triggered when losing hunger                                                                                      | The hunger lost                               | -               |
-| `lose_potion_effect`            | Triggered when losing a potion effect                                                                             | 1                                             | -               |
-| `mcmmo_ability_activate`        | Triggered when an McMMO ability is activated **Requires McMMO**                                                   | 1                                             | -               |
-| `mcmmo_ability_deactivate`      | Triggered when an McMMO ability is deactivated **Requires McMMO**                                                 | 1                                             | -               |
-| `melee_attack`                  | Triggered when injuring an entity with a melee attack                                                             | The damage dealt                              | -               |
-| `mine_block`                    | Triggered when mining a block                                                                                     | 1                                             | -               |
-| `mine_block_progress`           | Triggered when damaging a block                                                                                   | 1                                             | -               |
-| `move`                          | Triggered on all movement: looking around, walking                                                                | The distance moved                            | -               |
-| `pick_up_item`                  | Triggered when picking up an item                                                                                 | The amount of items                           | -               |
-| `place_block`                   | Triggered when placing a block                                                                                    | 1                                             | -               |
-| `plant_custom_crop`             | Triggered when planting a custom crop **Requires CustomCrops**                                                    | 1                                             | -               |
-| `player_trade`                  | Triggered when trading with a player **Required AxTrade**                                                         | The total amount of items traded              | -               |
-| `potion_effect`                 | Triggered when gaining a potion effect                                                                            | 1                                             | -               |
-| `projectile_hit`                | Triggered when hitting a block or an entity with a projectile (arrow, trident, splash potion, egg, snowball)      | 1                                             | -               |
-| `projectile_launch`             | Triggered when launching a projectile (arrow, trident, splash potion, egg, snowball)                              | 1                                             | -               |
-| `reel_in`                       | Triggered when reeling in a fishing rod                                                                           | 1                                             | -               |
-| `regen_magic`                   | Triggered when regenerating magic **Requires EcoSkills**                                                          | 1                                             | -               |
-| `register_vote`                 | Triggered when a player votes for the server **Requires NuVotifier**                                              | 1                                             | -               |
-| `rename_entity`                 | Triggered when a player renames an entity using a name tag **Requires Paper**                                     | 1                                             | -               |
-| `respawn`                       | Triggered when respawning                                                                                         | 1                                             | -               |
-| `right_click_npc`               | Triggered when right-clicking an NPC **Requires Citizens \|\| FancyNpcs**                                         | 1                                             | -               |
-| `ring_bell`                     | Triggered when ringing a bell                                                                                     | 1                                             | -               |
-| `run_command`                   | Triggered when running a command                                                                                  | 1                                             | -               |
-| `scyther_auto_collect`          | Triggered when autocollecting crops with a scyther hoe **Requires Scyther**                                       | 1                                             | -               |
-| `scyther_auto_sell`             | Triggered when autoselling crops with a scyther hoe **Requires Scyther**                                          | 1                                             | -               |
-| `sell_item`                     | Triggered when selling an item in a shop                                                                          | The price                                     | -               |
-| `send_message`                  | Triggered when sending a message                                                                                  | 1                                             | -               |
-| `shear_entity`                  | Triggered when shearing an entity                                                                                 | 1                                             | -               |
-| `shield_block`                  | Triggered when blocking an attack with a shield                                                                   | The damage blocked                            | -               |
-| `shoot_bow`                     | Triggered when shooting a bow                                                                                     | The force the bow was shot at between 0 and 1 | -               |
-| `smelt`                         | Triggered when smelting an item in a furnace                                                                      | The amount of items smelted                   | -               |
-| `smith_item`                    | Triggered when smithing an item in a smithing table                                                               | 1                                             | -               |
-| `start_quest`                   | Triggered when starting a quest **Requires EcoQuests**                                                            | 1                                             | -               |
-| `static_%interval%`             | Run every x ticks, eg `static_20` would run every second                                                          | 1                                             | -               |
-| `swap_hands`                    | Triggered when swapping items in hands (F by default)                                                             | 1                                             | -               |
-| `swing`                         | Triggered when swinging an item, hand or weapon **Requires Paper**                                                | 1                                             | -               |
-| `take_damage`                   | Triggered when taking damage from any source                                                                      | The damage taken                              | -               |
-| `take_entity_damage`            | Triggered when taking damage from an entity or player                                                             | The damage taken                              | -               |
-| `tame_animal`                   | Triggered when taming an animal                                                                                   | 1                                             | -               |
-| `teleport`                      | Triggered when teleporting                                                                                        | 1                                             | -               |
-| `tier_up_battlepass`            | Triggered when tiering up the battlepass **Requires xBattlepass**                                                 | The new level                                 | -               |
-| `toggle_flight`                 | Triggered when changing the flight state                                                                          | 1                                             | -               |
-| `toggle_sneak`                  | Triggered when changing the sneak state                                                                           | 1                                             | -               |
-| `toggle_sprint`                 | Triggered when changing the sprint state                                                                          | 1                                             | -               |
-| `trident_attack`                | Triggered on injuring an entity with a thrown trident **Requires Paper**                                          | The damage dealt                              | -               |
-| `try_inscribe`                  | Triggered when attempting to inscribe a scroll **Requires EcoScrolls**                                            | 1                                             | -               |
-| `unclaim`                       | Triggered when unclaiming an area **Requires HuskTowns \|\| HuskClaims**                                          | 1                                             | -               |
-| `unleash_entity`                | Triggered when unleashing an entity                                                                               | 1                                             | -               |
-| `use_fertilizer`                | Triggered when using fertilizer **Requires CustomCrops**                                                          | 1                                             | -               |
-| `use_flower_pot`                | Triggered when a player insets or extracts a plant from a flower pot **Requires Paper**                           | 1                                             | -               |
-| `use_watering_can`              | Triggered when using a watering can **Requires CustomCrops**                                                      | 1                                             | -               |
-| `villager_trade`                | Triggered when trading with a villager **Requires Paper**                                                         | The experience the villager gains             | -               |
-| `win_raid`                      | Triggered when a player wins a raid                                                                               | The level of bad omen                         | -               |
+| ID                              | Description                                                                                                       | Value(s)                                               |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `alt_click`                     | Triggered when using Right Click on most items, Left Click on those that have a default right click functionality | `value: 1`                                             |
+| `beacon_effect`                 | Triggered when a player gains effects from a beacon **Requires Paper**                                            | `value: 1`                                             |
+| `bite`                          | Triggered when a fish bites on your rod                                                                           | `value: 1`                                             |
+| `block_item_drop`               | Triggered when a mined block drops loot                                                                           | `value: The amount of items dropped`                   |
+| `bonemeal_crop`                 | Triggered when using bonemeal on a crop **Supports CustomCrops**                                                  | `value: 1`                                             |
+| `bow_attack`                    | Triggered when shooting an entity with a bow and arrow (or crossbow)                                              | `value: The damage dealt`                              |
+| `breed`                         | Triggered when breeding entities together                                                                         | `value: The experience received`                       |
+| `brew`                          | Triggered when brewing a potion in a brewing stand                                                                | `value: 1`                                             |
+| `brew_ingredient`               | Same as `brew`, but passes the ingredient as the item                                                             | `value: 1`                                             |
+| `cast_rod`                      | Triggered when casting a fishing line                                                                             | `value: 1`                                             |
+| `catch_entity`                  | Triggered when hooking onto an entity with a fishing rod                                                          | `value: 1`                                             |
+| `catch_fish`                    | Triggered when catching a fish                                                                                    | `value: The experience dropped`                        |
+| `catch_fish_fail`               | Triggered when failing to catch a fish                                                                            | `value: 1`                                             |
+| `change_armor`                  | Triggered when changing armor                                                                                     | `value: 1`                                             |
+| `change_chunk`                  | Triggered when changing chunk                                                                                     | `value: 1`                                             |
+| `change_world`                  | Triggered when changing world                                                                                     | `value: 1`                                             |
+| `click_block`                   | Triggered when right-clicking on a block                                                                          | `value: 1`                                             |
+| `click_entity`                  | Triggered when right-clicking on an entity                                                                        | `value: 1`                                             |
+| `complete_advancement`          | Triggered when completing an advancement                                                                          | `value: 1`                                             |
+| `consume`                       | Triggered on item consumption                                                                                     | `value: 1`                                             |
+| `craft`                         | Triggered when crafting an item                                                                                   | `value: The amount of items crafted`                   |
+| `damage_item`                   | Triggered when damaging an item                                                                                   | `value: The damage`                                    |
+| `death`                         | Triggered on death from any sources                                                                               | `value: 1`                                             |
+| `deploy_elytra`                 | Triggered when the player starts elytra gliding                                                                   | `value: 1`                                             |
+| `disable`                       | Triggered when an item / enchant / etc disables                                                                   | `value: 1`                                             |
+| `drop_item`                     | Triggered when dropping an item                                                                                   | `value: The amount of items`                           |
+| `elytra_boost`                  | Triggered when a player boosts an elytra **Requires Paper**                                                       | `value: 1`                                             |
+| `empty_bucket`                  | Triggered when emptying a bucket                                                                                  | `value: 1`                                             |
+| `enable`                        | Triggered when an item / enchant / etc enables                                                                    | `value: 1`                                             |
+| `enter_bed`                     | Triggered when entering a bed                                                                                     | `value: 1`                                             |
+| `entity_break_door`             | Triggered when an entity breaks a door                                                                            | `value: 1`                                             |
+| `entity_catch_fire_from_block`  | Triggered when an entity catches fire from a block                                                                | `value: 1`                                             |
+| `entity_catch_fire_from_entity` | Triggered when an entity catches fire from an entity                                                              | `value: 1`                                             |
+| `entity_damage`                 | Triggered when an entity takes damage                                                                             | `value: The damage taken`                              |
+| `entity_damage_by_entity`       | Triggered when an entity takes damage from another entity                                                         | `value: The damage taken`                              |
+| `entity_death`                  | Triggered when an entity dies                                                                                     | `value: 1`                                             |
+| `entity_item_drop`              | Triggered when a killed entity drops loot                                                                         | `value: The amount of items dropped`                   |
+| `entity_spawn`                  | Triggered when an entity spawns                                                                                   | `value: 1`                                             |
+| `entity_target`                 | Triggered when an entity targets another entity                                                                   | `value: 1`                                             |
+| `entity_teleport`               | Triggered when an entity teleports                                                                                | `value: 1`                                             |
+| `fall_damage`                   | Triggered when taking fall damage                                                                                 | `value: The damage taken`                              |
+| `fill_bucket`                   | Triggered when filling a bucket                                                                                   | `value: 1`                                             |
+| `gain_hunger`                   | Triggered when gaining hunger points                                                                              | `value: The hunger gained`                             |
+| `gain_xp`                       | Triggered when gaining experience points                                                                          | `value: The xp gained`                                 |
+| `global_static_%interval%`      | Run every x ticks for the server, eg `global_static_20` would run every second                                    | `value: 1`                                             |
+| `headshot`                      | Triggered when hitting an enemy with a projectile in the head                                                     | `value: The damage dealt`                              |
+| `heal`                          | Triggered when regaining health                                                                                   | `value: The health regained`                           |
+| `hold_item`                     | Triggered when changing your held item                                                                            | `value: 1`                                             |
+| `hook_in_ground`                | Triggered when a fishing rod hook hits the ground                                                                 | `value: 1`                                             |
+| `item_break`                    | Triggered when breaking any item in your inventory (durability)                                                   | `value: 1`                                             |
+| `join`                          | Triggered when joining the server                                                                                 | `value: 1`                                             |
+| `jump`                          | Triggered when Jumping (pressing space)                                                                           | `value: 1`                                             |
+| `kill`                          | Triggered when a player kills a player or entity                                                                  | `value: The victim's max health`                       |
+| `leash_entity`                  | Triggered when leashing an entity                                                                                 | `value: 1`                                             |
+| `leave`                         | Triggered when leaving the server                                                                                 | `value: 1`                                             |
+| `leave_bed`                     | Triggered when leaving a bed                                                                                      | `value: 1`                                             |
+| `leave_land`                    | Triggered when leaving a Town                                                                                     | `value: 1`                                             |
+| `level_up_item`                 | Triggered when levelling up an item                                                                               | `value: The new item level`                            |
+| `level_up_xp`                   | Triggered when levelling up XP                                                                                    | `value: The new level`                                 |
+| `lose_hunger`                   | Triggered when losing hunger                                                                                      | `value: The hunger lost`                               |
+| `lose_potion_effect`            | Triggered when losing a potion effect                                                                             | `value: 1`                                             |
+| `melee_attack`                  | Triggered when injuring an entity with a melee attack                                                             | `value: The damage dealt`                              |
+| `mine_block`                    | Triggered when mining a block                                                                                     | `value: 1`                                             |
+| `mine_block_progress`           | Triggered when damaging a block                                                                                   | `value: 1`                                             |
+| `move`                          | Triggered on all movement: looking around, walking                                                                | `value: The distance moved`                            |
+| `pick_up_item`                  | Triggered when picking up an item                                                                                 | `value: The amount of items`                           |
+| `place_block`                   | Triggered when placing a block                                                                                    | `value: 1`                                             |
+| `potion_effect`                 | Triggered when gaining a potion effect                                                                            | `value: 1`                                             |
+| `projectile_hit`                | Triggered when hitting a block or an entity with a projectile (arrow, trident, splash potion, egg, snowball)      | `value: 1`                                             |
+| `projectile_launch`             | Triggered when launching a projectile (arrow, trident, splash potion, egg, snowball)                              | `value: 1`                                             |
+| `reel_in`                       | Triggered when reeling in a fishing rod                                                                           | `value: 1`                                             |
+| `rename_entity`                 | Triggered when a player renames an entity using a name tag **Requires Paper**                                     | `value: 1`                                             |
+| `respawn`                       | Triggered when respawning                                                                                         | `value: 1`                                             |
+| `ring_bell`                     | Triggered when ringing a bell                                                                                     | `value: 1`                                             |
+| `run_command`                   | Triggered when running a command                                                                                  | `value: 1`                                             |
+| `sell_item`                     | Triggered when selling an item in a shop                                                                          | `value: The price`                                     |
+| `send_message`                  | Triggered when sending a message                                                                                  | `value: 1`                                             |
+| `shear_entity`                  | Triggered when shearing an entity                                                                                 | `value: 1`                                             |
+| `shield_block`                  | Triggered when blocking an attack with a shield                                                                   | `value: The damage blocked`                            |
+| `shoot_bow`                     | Triggered when shooting a bow                                                                                     | `value: The force the bow was shot at between 0 and 1` |
+| `smelt`                         | Triggered when smelting an item in a furnace                                                                      | `value: The amount of items smelted`                   |
+| `smith_item`                    | Triggered when smithing an item in a smithing table                                                               | `value: 1`                                             |
+| `static_%interval%`             | Run every x ticks, eg `static_20` would run every second                                                          | `value: 1`                                             |
+| `swap_hands`                    | Triggered when swapping items in hands (F by default)                                                             | `value: 1`                                             |
+| `swing`                         | Triggered when swinging an item, hand or weapon **Requires Paper**                                                | `value: 1`                                             |
+| `take_damage`                   | Triggered when taking damage from any source                                                                      | `value: The damage taken`                              |
+| `take_entity_damage`            | Triggered when taking damage from an entity or player                                                             | `value: The damage taken`                              |
+| `tame_animal`                   | Triggered when taming an animal                                                                                   | `value: 1`                                             |
+| `teleport`                      | Triggered when teleporting                                                                                        | `value: 1`                                             |
+| `toggle_flight`                 | Triggered when changing the flight state                                                                          | `value: 1`                                             |
+| `toggle_sneak`                  | Triggered when changing the sneak state                                                                           | `value: 1`                                             |
+| `toggle_sprint`                 | Triggered when changing the sprint state                                                                          | `value: 1`                                             |
+| `trident_attack`                | Triggered on injuring an entity with a thrown trident **Requires Paper**                                          | `value: The damage dealt`                              |
+| `unleash_entity`                | Triggered when unleashing an entity                                                                               | `value: 1`                                             |
+| `use_flower_pot`                | Triggered when a player insets or extracts a plant from a flower pot **Requires Paper**                           | `value: 1`                                             |
+| `villager_trade`                | Triggered when trading with a villager **Requires Paper**                                                         | `value: The experience the villager gains`             |
+| `win_raid`                      | Triggered when a player wins a raid                                                                               | `value: The level of bad omen`                         |
 
+## EcoPlugin Triggers
+
+| ID               | Description                                                          | Plugin      | Value(s)                       |
+| ---------------- | -------------------------------------------------------------------- | ----------- | ------------------------------ |
+| `enchant_<type>` | Triggered when enchanting an item with a certain type of enchantment | EcoEnchants | `value: The xp cost`           |
+| `gain_job_xp`    | Triggered when gaining job experience points                         | EcoJobs     | `value: The experience gained` |
+| `join_job`       | Triggered when joining a job                                         | EcoJobs     | `value: The job level`         |
+| `leave_job`      | Triggered when leaving a job                                         | EcoJobs     | `value: The job level`         |
+| `level_up_job`   | Triggered when levelling up a job                                    | EcoJobs     | `value: The new level`         |
+| `gain_pet_xp`    | Triggered when gaining pet experience points                         | EcoPets     | `value: The experience gained` |
+| `level_up_pet`   | Triggered when levelling up a pet                                    | EcoPets     | `value: The new level`         |
+| `complete_task`  | Triggered when completing a task                                     | EcoQuests   | `value: 1`                     |
+| `complete_quest` | Triggered when completing a quest                                    | EcoQuests   | `value: 1`                     |
+| `gain_task_xp`   | Triggered when gaining task XP                                       | EcoQuests   | `value: The experience gained` |
+| `start_quest`    | Triggered when starting a quest                                      | EcoQuests   | `value: 1`                     |
+| `inscribe`       | Triggered when inscribing a scroll                                   | EcoScrolls  | `value: 1`                     |
+| `try_inscribe`   | Triggered when attempting to inscribe a scroll                       | EcoScrolls  | `value: 1`                     |
+| `buy_item`       | Triggered when buying an item in a shop                              | EcoShop     | `value: The price`             |
+| `gain_skill_xp`  | Triggered when gaining skill experience points                       | EcoSkills   | `value: The experience gained` |
+| `level_up_skill` | Triggered when levelling up                                          | EcoSkills   | `value: The new level`         |
+| `regen_magic`    | Triggered when regenerating magic                                    | EcoSkills   | `value: 1`                     |
+## External Integration Triggers
+
+| ID                         | Description                                            | Plugin                           | Value(s)                                                     |
+| -------------------------- | ------------------------------------------------------ | -------------------------------- | ------------------------------------------------------------ |
+| `collect_envoy`            | Triggered when collecting an envoy crate               | AxEnvoy                          | `value: 1`                                                   |
+| `player_trade`             | Triggered when trading with a player                   | AxTrade                          | `value: The total amount of items traded`                    |
+| `left_click_npc`           | Triggered when left-clicking an NPC                    | Citizens<br/>FancyNpcs            | `value: 1`                                                   |
+| `right_click_npc`          | Triggered when right-clicking an NPC                   | Citizens<br/>FancyNpcs            | `value: 1`                                                   |
+| `bonemeal_crop`            | Triggered when using bonemeal on a crop                | CustomCrops                      | `value: 1`                                                   |
+| `harvest_custom_crop`      | Triggered when harvesting a custom crop                | CustomCrops                      | `value: 1`                                                   |
+| `plant_custom_crop`        | Triggered when planting a custom crop                  | CustomCrops                      | `value: 1`                                                   |
+| `use_fertilizer`           | Triggered when using fertilizer                        | CustomCrops                      | `value: 1`                                                   |
+| `use_watering_can`         | Triggered when using a watering can                    | CustomCrops                      | `value: 1`                                                   |
+| `change_town_role`         | Triggered when changing town role                      | HuskTowns                        | `value: 1`                                                   |
+| `create_town`              | Triggered when creating a Town                         | HuskTowns                        | `value: 1`                                                   |
+| `disband_town`             | Triggered when disbanding a Town                       | HuskTowns                        | `value: 1`                                                   |
+| `join_town`                | Triggered when joining a Town                          | HuskTowns                        | `value: 1`                                                   |
+| `leave_town`               | Triggered when leaving a Town                          | HuskTowns                        | `value: 1`                                                   |
+| `enter_claim`              | Triggered when entering a claimed area                 | HuskTowns<br/>HuskClaims          | `value: 1`                                                   |
+| `claim`                    | Triggered when claiming an area                        | HuskTowns<br/>HuskClaims<br/>Lands | `value: 1`                                                   |
+| `exit_claim`               | Triggered when exiting a claimed area                  | HuskTowns<br/>HuskClaims<br/>Lands | `value: 1`                                                   |
+| `unclaim`                  | Triggered when unclaiming an area                      | HuskTowns<br/>HuskClaims<br/>Lands | `value: 1`                                                   |
+| `jobs_level_up`            | Triggered when levelling up a job                      | Jobs Reborn                      | `value: The new level`                                       |
+| `join_land`                | Triggered when joining a Land                          | Lands                            | `value: 1`                                                   |
+| `lands_bank_deposit`       | Triggered when depositing into the Lands bank          | Lands                            | `value: The value deposited`<br/>`alt-value: The new balance` |
+| `lands_bank_withdraw`      | Triggered when withdrawing from the Lands bank         | Lands                            | `value: The value withdrawn`<br/>`alt-value: The new balance` |
+| `lands_spawn_teleport`     | Triggered when teleporting to Lands spawn              | Lands                            | `value: 1`                                                   |
+| `gain_mcmmo_xp`            | Triggered when gaining McMMO xp                        | McMMO                            | `value: The xp gained`                                       |
+| `level_down_mcmmo`         | Triggered when levelling down McMMO skill              | McMMO                            | `value: The new level`                                       |
+| `level_up_mcmmo`           | Triggered when levelling up McMMO skill                | McMMO                            | `value: The new level`                                       |
+| `mcmmo_ability_activate`   | Triggered when an McMMO ability is activated           | McMMO                            | `value: 1`                                                   |
+| `mcmmo_ability_deactivate` | Triggered when an McMMO ability is deactivated         | McMMO                            | `value: 1`                                                   |
+| `scyther_auto_collect`     | Triggered when autocollecting crops with a scyther hoe | Scyther                          | `value: 1`                                                   |
+| `scyther_auto_sell`        | Triggered when autoselling crops with a scyther hoe    | Scyther                          | `value: 1`                                                   |
+| `register_vote`            | Triggered when a player votes for the server           | Votifier                         | `value: 1`                                                   |
+| `enter_region`             | Triggered when entering a region                       | WorldGuard                       | `value: 1`                                                   |
+| `leave_region`             | Triggered when leaving a region                        | WorldGuard                       | `value: 1`                                                   |
+| `claim_battlepass_reward`  | Triggered when claiming a battlepass reward            | xBattlepass                      | `value: 1`                                                   |
+| `complete_battlepass_task` | Triggered when completing a battlepass task            | xBattlepass                      | `value: 1`                                                   |
+| `gain_battlepass_xp`       | Triggered when gaining battlepass XP                   | xBattlepass                      | `value: The experience gained`                               |
+| `tier_up_battlepass`       | Triggered when tiering up the battlepass               | xBattlepass                      | `value: The new level`                                       |

--- a/docs/effects/external-integrations/axenvoy/all-triggers.md
+++ b/docs/effects/external-integrations/axenvoy/all-triggers.md
@@ -2,13 +2,16 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
-and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID              | Description                              | Value | Alt-Value |
-| --------------- | ---------------------------------------- | ----- | --------- |
-| `collect_envoy` | Triggered when collecting an envoy crate | 1     | -         |
-
+| ID              | Description                              | Value(s)   |
+| --------------- | ---------------------------------------- | ---------- |
+| `collect_envoy` | Triggered when collecting an envoy crate | `value: 1` |

--- a/docs/effects/external-integrations/axtrade/all-triggers.md
+++ b/docs/effects/external-integrations/axtrade/all-triggers.md
@@ -2,13 +2,16 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
-and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID             | Description                          | Value                        | Alt-Value |
-| -------------- | ------------------------------------ | ---------------------------- | --------- |
-| `player_trade` | Triggered when trading with a player | Total number of items traded | -         |
-
+| ID             | Description                          | Value(s)                                  |
+| -------------- | ------------------------------------ | ----------------------------------------- |
+| `player_trade` | Triggered when trading with a player | `value: The total amount of items traded` |

--- a/docs/effects/external-integrations/citizens/all-triggers.md
+++ b/docs/effects/external-integrations/citizens/all-triggers.md
@@ -2,14 +2,17 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
-and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID                | Description                          | Value | Alt-Value |
-| ----------------- | ------------------------------------ | ----- | --------- |
-| `left_click_npc`  | Triggered when left-clicking an NPC  | 1     | -         |
-| `right_click_npc` | Triggered when right-clicking an NPC | 1     | -         |
-
+| ID                | Description                          | Value(s)   |
+| ----------------- | ------------------------------------ | ---------- |
+| `left_click_npc`  | Triggered when left-clicking an NPC  | `value: 1` |
+| `right_click_npc` | Triggered when right-clicking an NPC | `value: 1` |

--- a/docs/effects/external-integrations/customcrops/all-triggers.md
+++ b/docs/effects/external-integrations/customcrops/all-triggers.md
@@ -2,15 +2,20 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders), and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID                    | Description                                      | Value | Alt-Value |
-| --------------------- | ------------------------------------------------ | ----- | --------- |
-| `bonemeal_crop`       | Triggered when applying bonemeal to custom crops | 1     | -         |
-| `harvest_custom_crop` | Triggered when harvesting a custom crop          | 1     | -         |
-| `plant_custom_crop`   | Triggered when planting a custom crop            | 1     | -         |
-| `use_fertilizer`      | Triggered when using fertilizer                  | 1     | -         |
-| `use_watering_can`    | Triggered when using a watering can              | 1     | -         |
+| ID                    | Description                             | Value(s)   |
+| --------------------- | --------------------------------------- | ---------- |
+| `bonemeal_crop`       | Triggered when using bonemeal on a crop | `value: 1` |
+| `harvest_custom_crop` | Triggered when harvesting a custom crop | `value: 1` |
+| `plant_custom_crop`   | Triggered when planting a custom crop   | `value: 1` |
+| `use_fertilizer`      | Triggered when using fertilizer         | `value: 1` |
+| `use_watering_can`    | Triggered when using a watering can     | `value: 1` |

--- a/docs/effects/external-integrations/customfishing/all-triggers.md
+++ b/docs/effects/external-integrations/customfishing/all-triggers.md
@@ -2,15 +2,17 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect
-is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
-and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID                | Description                            | Value | Alt-Value |
-| ----------------- | -------------------------------------- | ----- | --------- |
-| `catch_fish`      | Triggered when catching a fish         | 1     | -         |
-| `catch_fish_fail` | Triggered when failing to catch a fish | 1     | -         |
-
+| ID                | Description                            | Value(s)   |
+| ----------------- | -------------------------------------- | ---------- |
+| `catch_fish`      | Triggered when catching a fish         | `value: 1` |
+| `catch_fish_fail` | Triggered when failing to catch a fish | `value: 1` |

--- a/docs/effects/external-integrations/fancynpcs/all-triggers.md
+++ b/docs/effects/external-integrations/fancynpcs/all-triggers.md
@@ -2,14 +2,17 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
-and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID                | Description                          | Value | Alt-Value |
-| ----------------- | ------------------------------------ | ----- | --------- |
-| `left_click_npc`  | Triggered when left-clicking an NPC  | 1     | -         |
-| `right_click_npc` | Triggered when right-clicking an NPC | 1     | -         |
-
+| ID                | Description                          | Value(s)   |
+| ----------------- | ------------------------------------ | ---------- |
+| `left_click_npc`  | Triggered when left-clicking an NPC  | `value: 1` |
+| `right_click_npc` | Triggered when right-clicking an NPC | `value: 1` |

--- a/docs/effects/external-integrations/huskclaims/all-triggers.md
+++ b/docs/effects/external-integrations/huskclaims/all-triggers.md
@@ -2,15 +2,19 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
-and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID            | Description                            | Value | Alt-Value |
-| ------------- | -------------------------------------- | ----- | --------- |
-| `claim`       | Triggered when claiming an area        | 1     | -         |
-| `enter_claim` | Triggered when entering a claimed area | 1     | -         |
-| `exit_claim`  | Triggered when exiting a claimed area  | 1     | -         |
-| `unclaim`     | Triggered when unclaiming an area      | 1     | -         |
+| ID            | Description                            | Value(s)   |
+| ------------- | -------------------------------------- | ---------- |
+| `enter_claim` | Triggered when entering a claimed area | `value: 1` |
+| `claim`       | Triggered when claiming an area        | `value: 1` |
+| `exit_claim`  | Triggered when exiting a claimed area  | `value: 1` |
+| `unclaim`     | Triggered when unclaiming an area      | `value: 1` |

--- a/docs/effects/external-integrations/husktowns/all-triggers.md
+++ b/docs/effects/external-integrations/husktowns/all-triggers.md
@@ -2,21 +2,24 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect
-is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
-and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID                 | Description                            | Value | Alt-Value |
-| ------------------ | -------------------------------------- | ----- | --------- |
-| `change_town_role` | Triggered when chaing town role        | 1     | -         |
-| `claim`            | Triggered when claiming an area        | 1     | -         |
-| `create_town`      | Triggered when creating a Town         | 1     | -         |
-| `disband_town`     | Triggered when disbanding a Town       | 1     | -         |
-| `enter_claim`      | Triggered when entering a claimed area | 1     | -         |
-| `exit_claim`       | Triggered when exiting a claimed area  | 1     | -         |
-| `join_town`        | Triggered when joining a Town          | 1     | -         |
-| `leave_town`       | Triggered when leaving a Town          | 1     | -         |
-| `unclaim`          | Triggered when unclaiming an area      | 1     | -         |
+| ID                 | Description                            | Value(s)   |
+| ------------------ | -------------------------------------- | ---------- |
+| `change_town_role` | Triggered when changing town role      | `value: 1` |
+| `create_town`      | Triggered when creating a Town         | `value: 1` |
+| `disband_town`     | Triggered when disbanding a Town       | `value: 1` |
+| `join_town`        | Triggered when joining a Town          | `value: 1` |
+| `leave_town`       | Triggered when leaving a Town          | `value: 1` |
+| `enter_claim`      | Triggered when entering a claimed area | `value: 1` |
+| `claim`            | Triggered when claiming an area        | `value: 1` |
+| `exit_claim`       | Triggered when exiting a claimed area  | `value: 1` |
+| `unclaim`          | Triggered when unclaiming an area      | `value: 1` |

--- a/docs/effects/external-integrations/jobs-reborn/all-triggers.md
+++ b/docs/effects/external-integrations/jobs-reborn/all-triggers.md
@@ -2,13 +2,16 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
-and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID              | Description                       | Value         | Alt-Value |
-| --------------- | --------------------------------- | ------------- | --------- |
-| `jobs_level_up` | Triggered when levelling up a job | The new level | -         |
-
+| ID              | Description                       | Value(s)               |
+| --------------- | --------------------------------- | ---------------------- |
+| `jobs_level_up` | Triggered when levelling up a job | `value: The new level` |

--- a/docs/effects/external-integrations/lands/all-triggers.md
+++ b/docs/effects/external-integrations/lands/all-triggers.md
@@ -2,20 +2,22 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
-and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID                     | Description                                    | Value               | AltValue        |
-| ---------------------- | ---------------------------------------------- | ------------------- | --------------- |
-| `claim`                | Triggered when claiming an area                | 1                   | -               |
-| `enter_claim`          | Triggered when entering a claimed area         | 1                   | -               |
-| `exit_claim`           | Triggered when exiting a claimed area          | 1                   | -               |
-| `join_land`            | Triggered when joining a Town                  | 1                   | -               |
-| `lands_bank_deposit`   | Triggered when depositing into the Lands bank  | The value deposited | The new balance |
-| `lands_bank_withdraw`  | Triggered when withdrawing from the Lands bank | The value withdrawn | The new balance |
-| `lands_spawn_teleport` | Triggered when teleporting to Lands spawn      | 1                   | -               |
-| `leave_land`           | Triggered when leaving a Town                  | 1                   | -               |
-| `unclaim`              | Triggered when unclaiming an area              | 1                   | -               |
+| ID                     | Description                                    | Value(s)                                                     |
+| ---------------------- | ---------------------------------------------- | ------------------------------------------------------------ |
+| `join_land`            | Triggered when joining a Land                  | `value: 1`                                                   |
+| `lands_bank_deposit`   | Triggered when depositing into the Lands bank  | `value: The value deposited`<br/>`alt-value: The new balance` |
+| `lands_bank_withdraw`  | Triggered when withdrawing from the Lands bank | `value: The value withdrawn`<br/>`alt-value: The new balance` |
+| `lands_spawn_teleport` | Triggered when teleporting to Lands spawn      | `value: 1`                                                   |
+| `claim`                | Triggered when claiming an area                | `value: 1`                                                   |
+| `exit_claim`           | Triggered when exiting a claimed area          | `value: 1`                                                   |
+| `unclaim`              | Triggered when unclaiming an area              | `value: 1`                                                   |

--- a/docs/effects/external-integrations/mcmmo/all-triggers.md
+++ b/docs/effects/external-integrations/mcmmo/all-triggers.md
@@ -2,17 +2,20 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
-and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID                         | Description                                    | Value         | Alt-Value |
-| -------------------------- | ---------------------------------------------- | ------------- | --------- |
-| `gain_mcmmo_xp`            | Triggered when gaining McMMO xp                | The xp gained | -         |
-| `level_down_mcmmo`         | Triggered when levelling down McMMO skill      | The new level | -         |
-| `level_up_mcmmo`           | Triggered when levelling up McMMO skill        | The new level | -         |
-| `mcmmo_ability_activate`   | Triggered when an McMMO ability is activated   | 1             | -         |
-| `mcmmo_ability_deactivate` | Triggered when an McMMO ability is deactivated | 1             | -         |
-
+| ID                         | Description                                    | Value(s)               |
+| -------------------------- | ---------------------------------------------- | ---------------------- |
+| `gain_mcmmo_xp`            | Triggered when gaining McMMO xp                | `value: The xp gained` |
+| `level_down_mcmmo`         | Triggered when levelling down McMMO skill      | `value: The new level` |
+| `level_up_mcmmo`           | Triggered when levelling up McMMO skill        | `value: The new level` |
+| `mcmmo_ability_activate`   | Triggered when an McMMO ability is activated   | `value: 1`             |
+| `mcmmo_ability_deactivate` | Triggered when an McMMO ability is deactivated | `value: 1`             |

--- a/docs/effects/external-integrations/paper/all-triggers.md
+++ b/docs/effects/external-integrations/paper/all-triggers.md
@@ -2,19 +2,22 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
-and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID               | Description                                                                             | Value                             | Alt-Value |
-| ---------------- | --------------------------------------------------------------------------------------- | --------------------------------- | --------- |
-| `beacon_effect`  | Triggered when a player gains effects from a beacon                                     | 1                                 | -         |
-| `elytra_boost`   | Triggered when a player boosts an elytra                                                | 1                                 | -         |
-| `rename_entity`  | Triggered when a player renames an entity using a name tag **Requires Paper**           | 1                                 | -         |
-| `swing`          | Triggered when swinging an item, hand or weapon                                         | 1                                 | -         |
-| `trident_attack` | Triggered on injuring an entity with a thrown trident                                   | The damage dealt                  | -         |
-| `use_flower_pot` | Triggered when a player insets or extracts a plant from a flower pot **Requires Paper** | 1                                 | -         |
-| `villager_trade` | Triggered when trading with a villager                                                  | The experience the villager gains | -         |
-
+| ID               | Description                                                                             | Value(s)                                   |
+| ---------------- | --------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `beacon_effect`  | Triggered when a player gains effects from a beacon                                     | `value: 1`                                 |
+| `elytra_boost`   | Triggered when a player boosts an elytra                                                | `value: 1`                                 |
+| `rename_entity`  | Triggered when a player renames an entity using a name tag **Requires Paper**           | `value: 1`                                 |
+| `swing`          | Triggered when swinging an item, hand or weapon                                         | `value: 1`                                 |
+| `trident_attack` | Triggered on injuring an entity with a thrown trident                                   | `value: The damage dealt`                  |
+| `use_flower_pot` | Triggered when a player insets or extracts a plant from a flower pot **Requires Paper** | `value: 1`                                 |
+| `villager_trade` | Triggered when trading with a villager                                                  | `value: The experience the villager gains` |

--- a/docs/effects/external-integrations/scyther/all-triggers.md
+++ b/docs/effects/external-integrations/scyther/all-triggers.md
@@ -2,14 +2,17 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
-and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID                     | Description                                            | Value | Alt-Value |
-| ---------------------- | ------------------------------------------------------ | ----- | --------- |
-| `scyther_auto_collect` | Triggered when autocollecting crops with a scyther hoe | 1     | -         |
-| `scyther_auto_sell`    | Triggered when autoselling crops with a scyther hoe    | 1     | -         |
-
+| ID                     | Description                                            | Value(s)   |
+| ---------------------- | ------------------------------------------------------ | ---------- |
+| `scyther_auto_collect` | Triggered when autocollecting crops with a scyther hoe | `value: 1` |
+| `scyther_auto_sell`    | Triggered when autoselling crops with a scyther hoe    | `value: 1` |

--- a/docs/effects/external-integrations/votifier/all-triggers.md
+++ b/docs/effects/external-integrations/votifier/all-triggers.md
@@ -2,13 +2,17 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
-and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID              | Description                                  | Value | Alt-Value |
-| --------------- | -------------------------------------------- | ----- | --------- |
-| `register_vote` | Triggered when a player votes for the server | 1     | -         |
+| ID              | Description                                  | Value(s)   |
+| --------------- | -------------------------------------------- | ---------- |
+| `register_vote` | Triggered when a player votes for the server | `value: 1` |
 

--- a/docs/effects/external-integrations/worldguard/all-triggers.md
+++ b/docs/effects/external-integrations/worldguard/all-triggers.md
@@ -2,14 +2,17 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
-and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID             | Description                      | Value | Alt-Value |
-| -------------- | -------------------------------- | ----- | --------- |
-| `enter_region` | Triggered when entering a region | 1     | -         |
-| `leave_region` | Triggered when leaving a region  | 1     | -         |
-
+| ID             | Description                      | Value(s)   |
+| -------------- | -------------------------------- | ---------- |
+| `enter_region` | Triggered when entering a region | `value: 1` |
+| `leave_region` | Triggered when leaving a region  | `value: 1` |

--- a/docs/effects/external-integrations/xbattlepass/all-triggers.md
+++ b/docs/effects/external-integrations/xbattlepass/all-triggers.md
@@ -2,15 +2,19 @@
 title: Triggers
 sidebar_position: 4
 ---
+Triggered effects require a trigger, these are the events/actions that cause the effects to run.
 
-Triggered effects require a trigger, permanent effects do not support triggers and instead always apply when the effect is active
+Triggers can also produce a `value`, and some produce an `alt-value`, you can reference these using their to scale multipliers, level up EcoSkills/Jobs/Pets, or send messages in chat.
 
-Triggered effects also produce a value, and some product an alt-value, which can be referenced with [their placeholders](https://plugins.auxilor.io/effects/configuring-an-effect#placeholders),
-and are used in plugins like EcoSkills, EcoPets, EcoJobs (etc) for levelling.
+| Placeholder           | Value                               | Aliases                                                                    |
+| --------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| `%trigger_value%`     | The value passed by the trigger     | `%triggervalue%`, `%trigger%`, `%value%`, `%tv%`, `%v%`, `%t%`             |
+| `%alt_trigger_value%` | The alt-value passed by the trigger | `%alttriggervalue%`, `%alttrigger%`, `%altvalue%`, `%atv%`, `%av%`, `%at%` |
+## Triggers
 
-| ID                         | Description                                 | Value                 | Alt-Value |
-| -------------------------- | ------------------------------------------- | --------------------- | --------- |
-| `claim_battlepass_reward`  | Triggered when claiming a battlepass reward | 1                     | -         |
-| `complete_battlepass_task` | Triggered when completing a battlepass task | 1                     | -         |
-| `gain_battlepass_xp`       | Triggered when gaining battlepass XP        | The experience gained | -         |
-| `tier_up_battlepass`       | Triggered when tiering up the battlepass    | The new level         | -         |
+| ID                         | Description                                 | Value(s)                       |
+| -------------------------- | ------------------------------------------- | ------------------------------ |
+| `claim_battlepass_reward`  | Triggered when claiming a battlepass reward | `value: 1`                     |
+| `complete_battlepass_task` | Triggered when completing a battlepass task | `value: 1`                     |
+| `gain_battlepass_xp`       | Triggered when gaining battlepass XP        | `value: The experience gained` |
+| `tier_up_battlepass`       | Triggered when tiering up the battlepass    | `value: The new level`         |


### PR DESCRIPTION
Updated trigger documentation across multiple plugin docs to standardize the explanation of triggers, added a table of trigger value placeholders and their aliases, and restructured trigger tables for clarity. The main triggers reference was expanded to categorize internal, EcoPlugin, and external integration triggers, and to consistently document value and alt-value outputs.