### PR TITLE
Document enchant_item trigger and clarify custom set example

### DIFF
--- a/docs/ecoarmor/how-to-make-a-custom-set.md
+++ b/docs/ecoarmor/how-to-make-a-custom-set.md
@@ -268,8 +268,8 @@ effects:
       - melee_attack
       - bow_attack
       - trident_attack
-      -
-        # The effects of the set (i.e. the functionality)
+      
+      # The effects of the set (i.e. the functionality)
       # See here: https://plugins.auxilor.io/effects/configuring-an-effect
 advancedEffects:
   - id: damage_multiplier

--- a/docs/effects/all-triggers.md
+++ b/docs/effects/all-triggers.md
@@ -45,6 +45,7 @@ Triggers can also produce a `value`, and some produce an `alt-value`, you can re
 | `elytra_boost`                  | Triggered when a player boosts an elytra **Requires Paper**                                                       | `value: 1`                                             |
 | `empty_bucket`                  | Triggered when emptying a bucket                                                                                  | `value: 1`                                             |
 | `enable`                        | Triggered when an item / enchant / etc enables                                                                    | `value: 1`                                             |
+| `enchant_item`                  | Triggered when enchanting an item in an enchanting table                                                          | `value: The xp cost`                                   |
 | `enter_bed`                     | Triggered when entering a bed                                                                                     | `value: 1`                                             |
 | `entity_break_door`             | Triggered when an entity breaks a door                                                                            | `value: 1`                                             |
 | `entity_catch_fire_from_block`  | Triggered when an entity catches fire from a block                                                                | `value: 1`                                             |


### PR DESCRIPTION
Added documentation for the 'enchant_item' trigger in all-triggers.md, specifying it is triggered when enchanting an item and provides the XP cost as value. Cleaned up formatting and comments in the custom set example in how-to-make-a-custom-set.md for better clarity.