### PR TITLE
Add EdPrison effects and conditions documentation

### DIFF
--- a/docs/ecojobs/how-to-make-a-custom-job.md
+++ b/docs/ecojobs/how-to-make-a-custom-job.md
@@ -208,7 +208,9 @@ For more advanced users or setups, you can configure chains in this section to s
 
 ## Internal Placeholders
 
-| Placeholder       | Value                                                       |
-| ----------------- | ----------------------------------------------------------- |
-| `%level%`         | The player's job level. Useful for creating scaling effects |
-| `%level_numeral%` | The player's job level shown in Roman Numerals              |
+| Placeholder       | Value                                                                    |
+| ----------------- |--------------------------------------------------------------------------|
+| `%level%`         | The player's job level. Useful for creating scaling effects              |
+| `%level_numeral%` | The player's job level shown in Roman Numerals                           |
+| `%level_x%`         | The player's job level, +/- a value. eg. `%level_-1%` is current level-1 |
+| `%level_x_numeral%` | The player's job level, +/- a value, shown as Numerals                   |

--- a/docs/ecopets/how-to-make-a-custom-pet.md
+++ b/docs/ecopets/how-to-make-a-custom-pet.md
@@ -154,7 +154,7 @@ xp-requirements:
 
 **level-commands:** Commands to be executed when levelling the pet.
 
-**entity-texture:** The texture of the pet that follows you around. Use `modelengine:<id>` if you're using Model Engine
+**entity-texture:** The texture of the pet that follows you around. Use `modelengine:<id>` if you're using Model Engine.
 
 **modelengine-animation:** If you're using Model Engine, you can supply an animation here
 
@@ -186,7 +186,9 @@ For more advanced users or setups, you can configure chains in this section to s
 
 ## Internal Placeholders
 
-| Placeholder       | Value                                                       |
-| ----------------- | ----------------------------------------------------------- |
-| `%level%`         | The player's pet level. Useful for creating scaling effects |
-| `%level_numeral%` | The player's pet level shown in Roman Numerals              |
+| Placeholder         | Value                                                                    |
+|---------------------|--------------------------------------------------------------------------|
+| `%level%`           | The player's pet level. Useful for creating scaling effects              |
+| `%level_numeral%`   | The player's pet level shown as Numerals                                 |
+| `%level_x%`         | The player's pet level, +/- a value. eg. `%level_-1%` is current level-1 |
+| `%level_x_numeral%` | The player's pet level, +/- a value, shown as Numerals                   |

--- a/docs/ecoquests/commands-and-permissions.md
+++ b/docs/ecoquests/commands-and-permissions.md
@@ -24,3 +24,9 @@ General Usage: `/ecoquests reset <player> <quest>`
 Permission: `ecoquests.command.start`
 
 General Usage: `/ecoquests start <player> <quest>`
+
+## `/ecoquests addexp (Add quest experience)`
+
+Permission: `ecoquests.command.addexp`
+
+General Usage: `/ecoquests addexp <player> <quest> <task> <amount>`

--- a/docs/ecoshop/how-to-make-an-item.md
+++ b/docs/ecoshop/how-to-make-an-item.md
@@ -50,59 +50,8 @@ to use a unique ID for every item in all of your shops. This is used in commands
 
 **row/column/page:** The location of this item in the shop
 
-### Command Items
 
-Sometimes you want to run a command when a player buys an item, such as giving permissions/ranks/items from other plugins not currently supported in the [Item Lookup System](https://plugins.auxilor.io/all-plugins/the-item-lookup-system). 
-
-Of course, you can't sell a command, so they're buy-only.
-
-```yaml
-- id: iron_rank
-  command:
-    - lp user %player% parent set iron
-  buy:
-    value: "%ecomc_iron_price%"
-    type: crystals
-    display: "&b%value% Crystals ❖"
-	limit: 1
-  gui:
-    display:
-      item: diamond_chestplate name:"&aIron Rank"
-      lore:
-        - "&fBuy &7&lIRON&r&f rank to get"
-        - "&fthe following benefits:"
-        - " &8»&f &eExample Perk"
-      bottom-lore: # You can also add lore to be put under other lore (e.g. price, quick buy/sell info, etc.)
-        - ""
-        - "&e&oLeft click to buy with money,"
-        - "&e&oRight click to buy with &bCrystals ❖&e&o!"
-    column: 5 # The column.
-    row: 3 # The row.
-    page: 2 # The page.
-```
-
-### Understanding all the sections
-
-**id:** This is the internal ID of the item. Players don't see this, but it's important
-to use a unique ID for every item in all of your shops. This is used in commands, placeholders and referencing the item
-
-**command:** This is the command to be run when a player buys this item. You can use `%player%` and `%amount%` as placeholders.
-#### Buy
-
-**type/value/display:** This is standard configuration of prices, read here for more info: [Prices](https://plugins.auxilor.io/all-plugins/prices). Prices are configured per-item.
-
-**limit:** (Optional) The max amount of times a player can buy this item.
-#### GUI
-
-**display.item:** This is the item shown in the GUI, read here for more info: [Item Lookup System](https://plugins.auxilor.io/all-plugins/the-item-lookup-system). 
-
-**display.lore:** This is the lore shown on the item.
-
-**display.bottom-lore:** Lore shown under other lore, such as displaying prices.
-
-**row/column/page:** The location of this item in the shop
-
-### Effect Items
+## Buy Effect Items
 
 Instead of just using commands, EcoShop also has full access to the
 [effects system](https://plugins.auxilor.io/effects/configuring-an-effect), so you can run effects when a player buys an item, or even just put effects themselves in the shop.
@@ -111,7 +60,10 @@ Like commands, these are unsellable.
 
 ```yaml
 - id: my_effect_item
-  effects: [ ]
+  buy-effects:
+    - id: run_command
+      args:
+        command: "say %player% just bought this item!"
   buy:
     value: 65
     type: crystals
@@ -133,7 +85,7 @@ Like commands, these are unsellable.
 **id:** This is the internal ID of the item. Players don't see this, but it's important
 to use a unique ID for every item in all of your shops. This is used in commands, placeholders and referencing the item
 
-**effects:** These are the effects that are ran when the player buys the item. Read here for more info: [Configuring an Effect](https://plugins.auxilor.io/effects/configuring-an-effect). **Only Triggered Effects**.
+**buy-effects:** These are the effects that are ran when the player buys the item. Read here for more info: [Configuring an Effect](https://plugins.auxilor.io/effects/configuring-an-effect). **Only Triggered Effects**.
 #### Buy
 
 **type/value/display:** This is standard configuration of prices, read here for more info: [Prices](https://plugins.auxilor.io/all-plugins/prices). Prices are configured per-item.

--- a/docs/ecoskills/how-to-make-a-skill.md
+++ b/docs/ecoskills/how-to-make-a-skill.md
@@ -267,7 +267,9 @@ For more advanced users or setups, you can configure chains in this section to s
 
 ## Internal Placeholders
 
-| Placeholder       | Value                                                         |
-| ----------------- | ------------------------------------------------------------- |
-| `%level%`         | The player's skill level. Useful for creating scaling effects |
-| `%level_numeral%` | The player's skill level shown in Roman Numerals              |
+| Placeholder       | Value                                                                      |
+| ----------------- |----------------------------------------------------------------------------|
+| `%level%`         | The player's skill level. Useful for creating scaling effects              |
+| `%level_numeral%` | The player's skill level shown in Roman Numerals                           |
+| `%level_x%`         | The player's skill level, +/- a value. eg. `%level_-1%` is current level-1 |
+| `%level_x_numeral%` | The player's skill level, +/- a value, shown as Numerals                   |

--- a/docs/effects/all-conditions/has_edprison_currency.md
+++ b/docs/effects/all-conditions/has_edprison_currency.md
@@ -1,0 +1,13 @@
+# `has_edprison_currency`
+:::infoRequires:
+EdPrison
+:::
+
+Requires the player to have a certain amount of EdPrison currency.
+# Condition Syntax
+```yaml
+- id: has_edprison_currency
+  args:
+    type: blocks # The currency type
+    amount: 1500 # The amnount of currency required
+```

--- a/docs/effects/all-conditions/has_edprison_robot.md
+++ b/docs/effects/all-conditions/has_edprison_robot.md
@@ -1,0 +1,12 @@
+# `has_edprison_robot`
+:::infoRequires:
+EdPrison
+:::
+
+Requires the player to have a specific EdPrison robot.
+# Condition Syntax
+```yaml
+- id: has_edprison_robot
+  args:
+    robot: COAL_ROBOT # The currency type
+```

--- a/docs/effects/all-conditions/in_edprison_gang.md
+++ b/docs/effects/all-conditions/in_edprison_gang.md
@@ -1,0 +1,10 @@
+# `in_edprison_gang`
+:::infoRequires:
+EdPrison
+:::
+
+Requires the player to be in a EdPrison gang.
+# Condition Syntax
+```yaml
+- id: in_edprison_gang
+```

--- a/docs/effects/all-effects/give_edprison_economy.md
+++ b/docs/effects/all-effects/give_edprison_economy.md
@@ -1,0 +1,18 @@
+# `give_edprison_economy`
+:::infoRequires:
+EdPrison
+:::
+
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
+
+Gives the player EdPrison economy.
+# Effect Syntax
+```yaml
+- id: give_edprison_economy
+  args:
+    amount: 100 # The amount of economy to give
+    type: blocks # The ID of the economy type
+  ...other config (eg triggers, filters, mutators, etc)
+```

--- a/docs/effects/all-effects/give_edprison_pouch.md
+++ b/docs/effects/all-effects/give_edprison_pouch.md
@@ -1,0 +1,18 @@
+# `give_edprison_pouch`
+:::infoRequires:
+EdPrison
+:::
+
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
+
+Gives the player an EdPrison pouch.
+# Effect Syntax
+```yaml
+- id: give_edprison_pouch
+  args:
+    type: blocks # the ID of the pouch type
+    unlocked: true # Whether the pouch is unlocked
+  ...other config (eg triggers, filters, mutators, etc)
+```

--- a/docs/effects/all-effects/multiply_edprison_economy.md
+++ b/docs/effects/all-effects/multiply_edprison_economy.md
@@ -1,0 +1,19 @@
+# `multiply_edprison_economy`
+:::infoRequires:
+EdPrison
+:::
+
+:::dangerPermanent Effect
+This effect is permanent and does not require a trigger.
+:::
+
+Multiplies incomming EdPrison economy.
+# Effect Syntax
+```yaml
+- id: multiply_edprison_economy
+  args:
+    multiplier: 1.5 # The xp multiplier
+    economies: # The economy types to multiply
+      - blocks
+      - tokens
+```

--- a/docs/effects/all-effects/play_sound.md
+++ b/docs/effects/all-effects/play_sound.md
@@ -12,5 +12,6 @@ Plays a sound to the player
     sound: entity_wolf_growl # The sound to play (https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Sound.html)
     pitch: 0.7 # The pitch of the sound (0.5 - 2)
     volume: 10 # The volume of the sound
+    category: MASTER # The sound category (https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/SoundCategory.html)
   ...other config (eg triggers, filters, mutators, etc)
 ```

--- a/docs/effects/all-effects/set_edprison_economy.md
+++ b/docs/effects/all-effects/set_edprison_economy.md
@@ -1,0 +1,18 @@
+# `set_edprison_economy`
+:::infoRequires:
+EdPrison
+:::
+
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
+
+Sets the EdPrison economy for the player
+# Effect Syntax
+```yaml
+- id: set_edprison_economy
+  args:
+    type: blocks # the ID of the economy type
+    amount: 100 # The amount to set
+  ...other config (eg triggers, filters, mutators, etc)
+```

--- a/docs/effects/all-effects/update_edprison_pickaxe.md
+++ b/docs/effects/all-effects/update_edprison_pickaxe.md
@@ -1,0 +1,15 @@
+# `update_edprison_pickaxe`
+:::infoRequires:
+EdPrison
+:::
+
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
+
+Updates the player's EdPrison pickaxe
+# Effect Syntax
+```yaml
+- id: set_edprison_economy
+  ...other config (eg triggers, filters, mutators, etc)
+```

--- a/docs/effects/external-integrations/edprison/_category_.json
+++ b/docs/effects/external-integrations/edprison/_category_.json
@@ -1,0 +1,3 @@
+{
+    "label": "EdPrison"
+}

--- a/docs/effects/external-integrations/edprison/conditions/_category_.json
+++ b/docs/effects/external-integrations/edprison/conditions/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Conditions",
+    "position": 2
+}

--- a/docs/effects/external-integrations/edprison/conditions/has_edprison_currency.md
+++ b/docs/effects/external-integrations/edprison/conditions/has_edprison_currency.md
@@ -1,0 +1,13 @@
+# `has_edprison_currency`
+:::infoRequires:
+EdPrison
+:::
+
+Requires the player to have a certain amount of EdPrison currency.
+# Condition Syntax
+```yaml
+- id: has_edprison_currency
+  args:
+    type: blocks # The currency type
+    amount: 1500 # The amnount of currency required
+```

--- a/docs/effects/external-integrations/edprison/conditions/has_edprison_robot.md
+++ b/docs/effects/external-integrations/edprison/conditions/has_edprison_robot.md
@@ -1,0 +1,12 @@
+# `has_edprison_robot`
+:::infoRequires:
+EdPrison
+:::
+
+Requires the player to have a specific EdPrison robot.
+# Condition Syntax
+```yaml
+- id: has_edprison_robot
+  args:
+    robot: COAL_ROBOT # The currency type
+```

--- a/docs/effects/external-integrations/edprison/conditions/in_edprison_gang.md
+++ b/docs/effects/external-integrations/edprison/conditions/in_edprison_gang.md
@@ -1,0 +1,10 @@
+# `in_edprison_gang`
+:::infoRequires:
+EdPrison
+:::
+
+Requires the player to be in a EdPrison gang.
+# Condition Syntax
+```yaml
+- id: in_edprison_gang
+```

--- a/docs/effects/external-integrations/edprison/effects/_category_.json
+++ b/docs/effects/external-integrations/edprison/effects/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Effects",
+    "position": 1
+}

--- a/docs/effects/external-integrations/edprison/effects/give_edprison_economy.md
+++ b/docs/effects/external-integrations/edprison/effects/give_edprison_economy.md
@@ -1,0 +1,18 @@
+# `give_edprison_economy`
+:::infoRequires:
+EdPrison
+:::
+
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
+
+Gives the player EdPrison economy.
+# Effect Syntax
+```yaml
+- id: give_edprison_economy
+  args:
+    amount: 100 # The amount of economy to give
+    type: blocks # The ID of the economy type
+  ...other config (eg triggers, filters, mutators, etc)
+```

--- a/docs/effects/external-integrations/edprison/effects/give_edprison_pouch.md
+++ b/docs/effects/external-integrations/edprison/effects/give_edprison_pouch.md
@@ -1,0 +1,18 @@
+# `give_edprison_pouch`
+:::infoRequires:
+EdPrison
+:::
+
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
+
+Gives the player an EdPrison pouch.
+# Effect Syntax
+```yaml
+- id: give_edprison_pouch
+  args:
+    type: blocks # the ID of the pouch type
+    unlocked: true # Whether the pouch is unlocked
+  ...other config (eg triggers, filters, mutators, etc)
+```

--- a/docs/effects/external-integrations/edprison/effects/multiply_edprison_economy.md
+++ b/docs/effects/external-integrations/edprison/effects/multiply_edprison_economy.md
@@ -1,0 +1,19 @@
+# `multiply_edprison_economy`
+:::infoRequires:
+EdPrison
+:::
+
+:::dangerPermanent Effect
+This effect is permanent and does not require a trigger.
+:::
+
+Multiplies incomming EdPrison economy.
+# Effect Syntax
+```yaml
+- id: multiply_edprison_economy
+  args:
+    multiplier: 1.5 # The xp multiplier
+    economies: # The economy types to multiply
+      - blocks
+      - tokens
+```

--- a/docs/effects/external-integrations/edprison/effects/set_edprison_economy.md
+++ b/docs/effects/external-integrations/edprison/effects/set_edprison_economy.md
@@ -1,0 +1,18 @@
+# `set_edprison_economy`
+:::infoRequires:
+EdPrison
+:::
+
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
+
+Sets the EdPrison economy for the player
+# Effect Syntax
+```yaml
+- id: set_edprison_economy
+  args:
+    type: blocks # the ID of the economy type
+    amount: 100 # The amount to set
+  ...other config (eg triggers, filters, mutators, etc)
+```

--- a/docs/effects/external-integrations/edprison/effects/update_edprison_pickaxe.md
+++ b/docs/effects/external-integrations/edprison/effects/update_edprison_pickaxe.md
@@ -1,0 +1,15 @@
+# `update_edprison_pickaxe`
+:::infoRequires:
+EdPrison
+:::
+
+:::dangerTriggered Effect
+This effect requires a [Trigger](https://plugins.auxilor.io/effects/all-triggers) to activate.
+:::
+
+Updates the player's EdPrison pickaxe
+# Effect Syntax
+```yaml
+- id: set_edprison_economy
+  ...other config (eg triggers, filters, mutators, etc)
+```


### PR DESCRIPTION
Introduces documentation for EdPrison-related effects and conditions, including new markdown files and category JSONs for external integrations. Updates placeholders in ecojobs, ecopets, and ecoskills guides to support +/- level values. Revises EcoShop item documentation to clarify buy-effects usage and removes command item section. Adds new command documentation for ecoquests and updates play_sound effect with sound category.