### PR TITLE
Rename effect docs header to cast_mythic_skill

### DIFF
--- a/docs/effects/all-effects/cast_mythic_skill.md
+++ b/docs/effects/all-effects/cast_mythic_skill.md
@@ -1,4 +1,4 @@
-# `add_stat`
+# `cast_mythic_skill`
 :::infoRequires:
 MythicMobs
 :::

--- a/docs/effects/external-integrations/mythicmobs/effects/cast_mythic_skill.md
+++ b/docs/effects/external-integrations/mythicmobs/effects/cast_mythic_skill.md
@@ -1,4 +1,4 @@
-# `add_stat`
+# `cast_mythic_skill`
 :::infoRequires:
 MythicMobs
 :::


### PR DESCRIPTION
Fix the heading in two documentation files to `cast_mythic_skill` (previously `add_stat`). Updated files: docs/effects/all-effects/cast_mythic_skill.md and docs/effects/external-integrations/mythicmobs/effects/cast_mythic_skill.md. No other content was changed.