### PR TITLE
Document projectile pickup option

### DIFF
--- a/docs/effects/all-effects/shoot.md
+++ b/docs/effects/all-effects/shoot.md
@@ -13,5 +13,6 @@ Shoots a [projectile](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity
     no_source: false # If the player should not be marked as the source, leaving this option out defaults to false
     projectile: arrow # The name of the projectile
     launch-at-location: false # If the projectile should be launched at the location of the trigger rather than the player (Default: false)
+    allow_pickup: false # If fired arrow-like projectiles can be picked back up (Default: false)
   ...other config (eg triggers, filters, mutators, etc)
 ```

--- a/docs/effects/all-effects/shoot_arrow.md
+++ b/docs/effects/all-effects/shoot_arrow.md
@@ -12,5 +12,6 @@ Shoots an arrow
     inherit_velocity: true # If velocity should be inherited from the trigger (ie if you want to make a tripleshot effect)
     no_source: false # If the player should not be marked as the source, leaving this option out defaults to false
     launch-at-location: false # If the arrow should be launched at the location of the trigger rather than the player (Default: false)
+    allow_pickup: false # If the fired arrow can be picked back up (Default: false)
   ...other config (eg triggers, filters, mutators, etc)
 ```


### PR DESCRIPTION
Documents the optional `allow_pickup` argument for `shoot_arrow` and `shoot`.

Related code PR: https://github.com/Auxilor/libreforge/pull/271